### PR TITLE
fix: tag Azure RBAC tasks as out-of-scope instead of silently dropping

### DIFF
--- a/pipeline/enrich.py
+++ b/pipeline/enrich.py
@@ -21,6 +21,28 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Tasks scraped from Microsoft Learn sometimes reference Azure RBAC roles
+# (Owner, Contributor, Reader) or non-role values. These aren't Entra
+# directory roles and should be tagged out_of_scope rather than dropped.
+AZURE_RBAC_ROLES = {
+    "owner",
+    "contributor",
+    "reader",
+    "user access administrator",
+    "reader on azure subscription containing ad ds service",
+}
+NON_ROLE_VALUES = {
+    "all non-guest users",
+    "all users",
+    "any user",
+    # Object/implicit roles — not Entra directory roles
+    "default user role",
+    "enterprise application owner",
+    "group owner",
+    "group member",
+    "aad dc administrators group",
+}
+
 GRAPH_ROLES_PATH = Path(__file__).parent.parent / "data" / "roles_graph_raw.json"
 DOCS_ROLES_PATH  = Path(__file__).parent.parent / "data" / "roles.json"
 TASKS_PATH       = Path(__file__).parent.parent / "data" / "tasks.json"
@@ -103,16 +125,35 @@ def enrich_tasks(tasks: list[dict], role_index: dict) -> tuple[list[dict], int]:
     unmatched: set[str] = set()
 
     for task in tasks:
-        role = role_index.get(task["min_role"].lower())
+        min_role_raw   = task["min_role"]
+        min_role_lower = min_role_raw.lower()
+        role = role_index.get(min_role_lower)
         enriched_task = dict(task)
+
         if role:
-            enriched_task["role_id"]      = role["id"]
+            # Normal case: resolved to an Entra directory role
+            enriched_task["role_id"]       = role["id"]
             enriched_task["is_privileged"] = role["isPrivileged"]
+            enriched_task["out_of_scope"]  = None
             matched += 1
-        else:
-            enriched_task["role_id"]      = None
+        elif min_role_lower in AZURE_RBAC_ROLES:
+            # Task requires Azure RBAC (not Entra) — tag explicitly
+            enriched_task["role_id"]       = None
             enriched_task["is_privileged"] = None
-            unmatched.add(task["min_role"])
+            enriched_task["out_of_scope"]  = "azure_rbac"
+            enriched_task["out_of_scope_role"] = min_role_raw
+        elif min_role_lower in NON_ROLE_VALUES:
+            # Task reference isn't a role at all — tag as informational
+            enriched_task["role_id"]       = None
+            enriched_task["is_privileged"] = None
+            enriched_task["out_of_scope"]  = "not_a_role"
+            enriched_task["out_of_scope_role"] = min_role_raw
+        else:
+            # Genuinely unexpected — warn for investigation
+            enriched_task["role_id"]       = None
+            enriched_task["is_privileged"] = None
+            enriched_task["out_of_scope"]  = None
+            unmatched.add(min_role_raw)
         enriched.append(enriched_task)
 
     for name in sorted(unmatched):

--- a/pipeline/push_to_cloudflare.py
+++ b/pipeline/push_to_cloudflare.py
@@ -220,11 +220,16 @@ def push_tasks(account_id: str, database_id: str, token: str,
     role_index: displayName.lower() -> id (GUID)
     Only tasks with a resolvable min_role_id are inserted (NOT NULL constraint).
     """
-    valid = [t for t in tasks if t.get("role_id")]
-    skipped = len(tasks) - len(valid)
-    if skipped:
-        print(f"  Skipping {skipped} tasks with no role_id (non-built-in min_role)")
+    in_scope     = [t for t in tasks if t.get("role_id")]
+    out_of_scope = [t for t in tasks if not t.get("role_id") and t.get("out_of_scope")]
+    dropped      = [t for t in tasks
+                    if not t.get("role_id") and not t.get("out_of_scope")]
+    if dropped:
+        print(f"  Dropping {len(dropped)} tasks with unrecognised min_role "
+              f"(investigate: {sorted({t['min_role'] for t in dropped})[:5]})")
+    print(f"  In-scope tasks: {len(in_scope)} | Out-of-scope (Azure RBAC/non-role): {len(out_of_scope)}")
 
+    valid = in_scope + out_of_scope
     print(f"Replacing {len(valid)} tasks in D1...")
 
     # Delete all existing tasks (task_search cascades)
@@ -233,8 +238,8 @@ def push_tasks(account_id: str, database_id: str, token: str,
     sql = (
         "INSERT INTO tasks "
         "(feature_area, task_description, min_role_id, alt_role_ids, "
-        "source_url, last_verified) "
-        "VALUES (?, ?, ?, ?, ?, ?)"
+        "source_url, last_verified, out_of_scope, out_of_scope_role) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
     )
 
     def resolve_guids(names: list[str]) -> list[str]:
@@ -247,10 +252,12 @@ def push_tasks(account_id: str, database_id: str, token: str,
             "params": [
                 t["feature_area"],
                 t["task"],                              # our field name
-                t["role_id"],                           # already a GUID
+                t.get("role_id"),                       # may be None for out-of-scope
                 json.dumps(resolve_guids(t.get("alt_roles", []))),
                 t.get("source_url", ""),
                 TODAY,
+                t.get("out_of_scope"),
+                t.get("out_of_scope_role"),
             ],
         }
         for t in valid

--- a/worker/migrations/0001_out_of_scope.sql
+++ b/worker/migrations/0001_out_of_scope.sql
@@ -1,0 +1,31 @@
+-- Migration 0001: add out_of_scope columns + relax NOT NULL on min_role_id
+--
+-- Step 1: add new columns to existing table
+ALTER TABLE tasks ADD COLUMN out_of_scope TEXT DEFAULT NULL;
+ALTER TABLE tasks ADD COLUMN out_of_scope_role TEXT DEFAULT NULL;
+
+-- Step 2: clear task_search so we can drop tasks (FK dependency)
+DELETE FROM task_search;
+
+-- Step 3: recreate tasks with nullable min_role_id
+CREATE TABLE tasks_new (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  feature_area   TEXT NOT NULL,
+  task_description TEXT NOT NULL,
+  min_role_id    TEXT,              -- was NOT NULL; relaxed for out-of-scope tasks
+  alt_role_ids   TEXT NOT NULL,
+  notes          TEXT,
+  source_url     TEXT,
+  last_verified  TEXT NOT NULL,
+  out_of_scope      TEXT DEFAULT NULL,
+  out_of_scope_role TEXT DEFAULT NULL
+);
+
+INSERT INTO tasks_new
+  SELECT id, feature_area, task_description, min_role_id,
+         alt_role_ids, notes, source_url, last_verified,
+         out_of_scope, out_of_scope_role
+  FROM tasks;
+
+DROP TABLE tasks;
+ALTER TABLE tasks_new RENAME TO tasks;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -135,6 +135,7 @@ async function runKeywordTier(
        FROM tasks t
        JOIN roles r ON t.min_role_id = r.id
        WHERE lower(t.task_description) LIKE '%' || lower(?1) || '%'
+         AND t.out_of_scope IS NULL
        LIMIT 5`
     ).bind(q).all(),
 
@@ -148,6 +149,7 @@ async function runKeywordTier(
        JOIN tasks t ON ts.task_id = t.id
        JOIN roles r ON t.min_role_id = r.id
        WHERE ts.keyword IN (${ph})
+         AND t.out_of_scope IS NULL
        GROUP BY t.id
        HAVING COUNT(DISTINCT ts.keyword) = ${count}
        ORDER BY base_score DESC
@@ -164,6 +166,7 @@ async function runKeywordTier(
        JOIN tasks t ON ts.task_id = t.id
        JOIN roles r ON t.min_role_id = r.id
        WHERE ts.keyword IN (${ph})
+         AND t.out_of_scope IS NULL
        GROUP BY t.id
        ORDER BY base_score DESC
        LIMIT 10`
@@ -211,8 +214,9 @@ async function runLikeTier(
        1 AS base_score
      FROM tasks t
      JOIN roles r ON t.min_role_id = r.id
-     WHERE lower(t.task_description) LIKE '%' || lower(?1) || '%'
-        OR lower(t.feature_area)     LIKE '%' || lower(?1) || '%'
+     WHERE (lower(t.task_description) LIKE '%' || lower(?1) || '%'
+        OR lower(t.feature_area)     LIKE '%' || lower(?1) || '%')
+       AND t.out_of_scope IS NULL
      LIMIT 10`
   ).bind(likeKw).all();
 


### PR DESCRIPTION
## Summary

- **30 tasks** referencing Azure RBAC roles (Owner, Contributor, Reader) or non-role values (Group owner, Default user role, etc.) were silently dropped by the pipeline's NOT NULL constraint on `min_role_id`. They now get tagged and stored.
- `enrich.py` classifies them as `azure_rbac` or `not_a_role` instead of leaving `role_id: null` with no explanation.
- `push_to_cloudflare.py` pushes out-of-scope tasks to D1 with the new columns (previously skipped entirely).
- `worker/src/index.ts` filters `AND t.out_of_scope IS NULL` in all 4 search queries so they never surface to users.
- D1 schema migrated: `out_of_scope TEXT`, `out_of_scope_role TEXT` columns added; `min_role_id` NOT NULL relaxed.

## Out-of-scope breakdown (30 tasks)

| Type | Role | Count |
|------|------|-------|
| azure_rbac | Contributor | 3 |
| azure_rbac | Owner | 2 |
| azure_rbac | Reader | 6 |
| azure_rbac | Reader on Azure subscription containing AD DS service | 1 |
| not_a_role | AAD DC Administrators group | 1 |
| not_a_role | All non-guest users | 1 |
| not_a_role | Default user role | 6 |
| not_a_role | Enterprise application owner | 6 |
| not_a_role | Group member | 1 |
| not_a_role | Group owner | 3 |

## Test plan

- [ ] Merge to master
- [ ] Pipeline runs (`gh workflow run refresh.yml --ref master`) — confirm log shows `In-scope tasks: 216 | Out-of-scope (Azure RBAC/non-role): 30`
- [ ] `SELECT COUNT(*), SUM(CASE WHEN out_of_scope IS NOT NULL THEN 1 ELSE 0 END) FROM tasks` → total ~246, oos ~30
- [ ] `GET /api/search?q=Connect+Health` returns no Owner/Contributor tasks
- [ ] Existing pill searches unchanged (no regression)

## Rollback

```bash
cd worker && npx wrangler rollback
npx wrangler d1 execute rolelens-db --remote --command "ALTER TABLE tasks DROP COLUMN out_of_scope; ALTER TABLE tasks DROP COLUMN out_of_scope_role;"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)