### PR TITLE
test: add pill integration tests to nightly pipeline

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -68,6 +68,23 @@ jobs:
           CLOUDFLARE_KV_NAMESPACE_ID: ${{ secrets.CLOUDFLARE_KV_NAMESPACE_ID }}
           D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
 
+      - name: Run pill integration tests
+        id: pill_tests
+        continue-on-error: true
+        run: python pipeline/test_pills.py
+        env:
+          WORKER_URL: https://rolelens-worker.russo-antonio76.workers.dev
+
+      - name: Open issue on pill regression
+        if: steps.pill_tests.outcome == 'failure'
+        run: |
+          gh issue create \
+            --title "Pill regression detected in nightly run $(date +%Y-%m-%d)" \
+            --body "The nightly pipeline detected that one or more documented pill queries no longer return the expected top result. Check the Actions log for the specific failures and investigate before the next deploy." \
+            --label "bug,pill-regression"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Commit and push data to master
         run: |
           git config user.name "github-actions[bot]"

--- a/pipeline/test_pills.py
+++ b/pipeline/test_pills.py
@@ -1,0 +1,86 @@
+"""
+test_pills.py
+
+Runs the documented pill expectations against the live worker
+and fails the nightly pipeline if any regress.
+
+Opens a GitHub issue on failure so regressions don't go silent.
+"""
+
+import os
+import sys
+from urllib.parse import quote
+
+import requests
+
+WORKER_URL = os.environ.get(
+    "WORKER_URL",
+    "https://rolelens-worker.russo-antonio76.workers.dev",
+)
+
+# Format: (query, expected_min_role_at_rank_1)
+# When adding new pills to the frontend, add expectations here.
+EXPECTATIONS: list[tuple[str, str]] = [
+    ("configure passkeys",          "Authentication Policy Administrator"),
+    ("backup",                      "Entra Backup Reader"),
+    ("reset password",              "Password Administrator"),
+    ("reset user password",         "Password Administrator"),
+    ("manage conditional access",   "Conditional Access Administrator"),
+    ("configure SSPR",              "Authentication Policy Administrator"),
+    ("manage AI agents",            "Agent ID Administrator"),
+    ("manage groups",               "Groups Administrator"),
+    ("manage administrative units", "Groups Administrator"),
+    ("manage Copilot governance",   "AI Administrator"),
+    ("GDAP relationships",          "Tenant Governance Relationship Administrator"),
+    ("restore deleted users",       "Entra Backup Administrator"),
+    ("audit AI usage",              "AI Reader"),
+    ("configure PIM",               "Privileged Role Administrator"),
+    ("approve access review",       "Identity Governance Administrator"),
+]
+
+
+def run_pill(query: str, expected_role: str) -> tuple[bool, str]:
+    """Returns (passed, detail_message)."""
+    url = f"{WORKER_URL}/api/search?q={quote(query)}"
+    try:
+        resp = requests.get(url, timeout=10)
+    except requests.RequestException as exc:
+        return False, f"network error: {exc}"
+
+    if not resp.ok:
+        return False, f"HTTP {resp.status_code}"
+
+    results = resp.json()
+    if not isinstance(results, list) or not results:
+        return False, "no results returned"
+
+    actual = results[0].get("min_role", "<missing>")
+    if actual == expected_role:
+        return True, f"OK -> {actual}"
+    return False, f"expected {expected_role!r}, got {actual!r}"
+
+
+def main() -> int:
+    print(f"Running {len(EXPECTATIONS)} pill tests against {WORKER_URL}")
+    print("-" * 72)
+    failures: list[str] = []
+    for query, expected in EXPECTATIONS:
+        passed, detail = run_pill(query, expected)
+        marker = "PASS" if passed else "FAIL"
+        print(f"  {marker}  {query!r:45s}  {detail}")
+        if not passed:
+            failures.append(f"  - {query!r}: {detail}")
+
+    print("-" * 72)
+    if failures:
+        print(f"\n{len(failures)} pill regression(s) detected:")
+        for line in failures:
+            print(line)
+        return 1
+
+    print(f"\nAll {len(EXPECTATIONS)} pills passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds 15-pill baseline integration test to refresh.yml. Runs after deploy with continue-on-error. Auto-opens GitHub issue on regression.

Baseline: 9/15 passing. The 6 failures are documented TODOs for Week 2 BM25 ranking work:

Category A — Verb-noise inflation (3 failures):
- configure SSPR → Entra Backup Administrator (expected Authentication Policy Administrator)
- configure PIM → Entra Backup Administrator (expected Privileged Role Administrator)
- manage groups → License Administrator (expected Groups Administrator)

Root cause: the new Entra Backup Administrator role (shipped 2026-04) has few tasks, all starting with 'Configure'. Raw keyword frequency on common verbs beats topic-specific relevance. Similarly, License Admin has many 'manage' tasks that outweigh Groups Admin's 'manage' tasks.

Category B — Other (3 failures):
- reset user password → External ID User Flow Administrator (expected Password Administrator)
- manage AI agents → Identity Governance Administrator (expected Agent ID Administrator)
- approve access review → Security Reader (expected Identity Governance Administrator)

Fix: BM25 TF-IDF scoring (Week 2, feat/search-v2 branch). Down-weights common verbs via IDF, upweights rare topic words. Expected to resolve Category A directly; Category B needs synonym/correlation refinement alongside BM25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)