### PR TITLE
data: tag 26 synthetic tasks in tasks.json

### DIFF
--- a/data/tasks.json
+++ b/data/tasks.json
@@ -1753,21 +1753,24 @@
       "Helpdesk Administrator",
       "User Administrator"
     ],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Security - Authentication methods",
     "task": "Configure SSPR self-service password reset policy",
     "min_role": "Authentication Policy Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Agent Identity",
     "task": "Manage AI agents and agent identities",
     "min_role": "Agent ID Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Groups",
@@ -1776,154 +1779,176 @@
     "alt_roles": [
       "User Administrator"
     ],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Privileged Identity Management",
     "task": "Configure PIM Privileged Identity Management settings and role assignments",
     "min_role": "Privileged Role Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Identity Governance",
     "task": "Approve and manage access reviews for users and groups",
     "min_role": "Identity Governance Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Agent Identity",
     "task": "Register an AI agent identity",
     "min_role": "Agent ID Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Agent Identity",
     "task": "View and manage AI agent identities",
     "min_role": "Agent ID Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Agent Identity",
     "task": "Develop and test AI agent service principals",
     "min_role": "Agent ID Developer",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Agent Identity",
     "task": "Manage the agent registry",
     "min_role": "Agent Registry Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Agent Identity",
     "task": "Read agent registry entries",
     "min_role": "Agent Registry Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Agent Identity",
     "task": "Configure AI policies and governance",
     "min_role": "AI Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Agent Identity",
     "task": "Read AI usage and audit data",
     "min_role": "AI Reader",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Agent Identity",
     "task": "View Copilot activity and permissions",
     "min_role": "AI Reader",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Backup and Recovery",
     "task": "Configure Entra ID backup settings",
     "min_role": "Entra Backup Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Backup and Recovery",
     "task": "Read Entra backup configuration",
     "min_role": "Entra Backup Reader",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Backup and Recovery",
     "task": "Restore deleted directory objects",
     "min_role": "Entra Backup Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Backup and Recovery",
     "task": "Manage tenant disaster recovery",
     "min_role": "Entra Backup Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Tenant Governance",
     "task": "Manage GDAP relationships with partners",
     "min_role": "Tenant Governance Relationship Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Tenant Governance",
     "task": "Read GDAP relationship status",
     "min_role": "Tenant Governance Relationship Reader",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Tenant Governance",
     "task": "Configure tenant governance policies",
     "min_role": "Tenant Governance Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Tenant Governance",
     "task": "Read tenant governance settings",
     "min_role": "Tenant Governance Reader",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Tenant Governance",
     "task": "Manage CSP delegated admin access",
     "min_role": "Tenant Governance Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Agent Identity",
     "task": "Manage Copilot and AI governance",
     "min_role": "AI Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Security - Authentication methods",
     "task": "Configure passkeys and FIDO2 authentication methods",
     "min_role": "Authentication Policy Administrator",
     "alt_roles": [],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   },
   {
     "feature_area": "Administrative units",
@@ -1932,6 +1957,7 @@
     "alt_roles": [
       "Privileged Role Administrator"
     ],
-    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference"
+    "source_url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference",
+    "synthetic": true
   }
 ]


### PR DESCRIPTION
Metadata-only change. Adds `synthetic: true` to 26 tasks that were curated by hand (via permissions-reference source URL) rather than scraped from Microsoft Learn's delegate-by-task page.

Breakdown:
- 10 Agent Identity (new role family)
- 5 Tenant Governance (GDAP)
- 4 Backup and Recovery (new Entra Backup roles)
- 7 across established feature areas (pill coverage)

No code changes. No ranking changes. No user-facing effect. Enables future audits to tell scraped vs curated content apart.

Verified locally:
- JSON parses correctly (237 tasks, 26 tagged)
- Pipeline has no strict schema validation (unknown fields ignored)
- First task (index 0) has no synthetic key — only the 26 curated tasks are tagged
- Diff is clean: 26 small additions, no reformatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)