### PR TITLE
feat(pipeline): port JS synonyms to Python, wire into pill tests

### DIFF
--- a/pipeline/synonyms.py
+++ b/pipeline/synonyms.py
@@ -1,0 +1,294 @@
+# Extracted 220 synonym entries from index.html
+import re
+
+SYNONYMS: dict[str, str] = {
+    # Short abbreviations that need synonym to bypass length gate
+    'ai':                           'ai administrator',
+
+    # Identity & access
+    'pim':                          'privileged identity management',
+    'privileged identity':          'privileged identity management',
+    'jit':                          'just in time access',
+    'just-in-time':                 'just in time access',
+    'rbac':                         'role based access control',
+    'role based access':            'role based access control',
+    'pac':                          'privileged access',
+    'pag':                          'privileged access group',
+
+    # Authentication
+    'mfa':                          'multi factor authentication',
+    'multi-factor':                 'multi factor authentication',
+    'multifactor':                  'multi factor authentication',
+    '2fa':                          'two factor authentication',
+    'two-factor':                   'two factor authentication',
+    'fido2':                        'passkey passwordless authentication',
+    'fido':                         'passkey passwordless authentication',
+    'passkey':                      'passwordless authentication',
+    'passwordless':                 'passwordless authentication',
+    'sspr':                         'self service password reset',
+    'self-service password':        'self service password reset',
+    'password reset':               'self service password reset',
+    'reset user password':          'reset user account password',
+    'tap':                          'temporary access pass',
+    'temporary access pass':        'temporary access pass',
+    'windows hello':                'passwordless authentication',
+
+    # Conditional Access & network
+    'ca':                           'conditional access',
+    'conditional access':           'conditional access',
+    'cap':                          'conditional access policy',
+    'named location':               'named locations conditional access',
+    'trusted location':             'named locations conditional access',
+    'ip range':                     'named locations conditional access',
+    'gsa':                          'global secure access',
+    'global secure access':         'global secure access',
+    'entra internet access':        'global secure access',
+    'entra private access':         'global secure access',
+    'ztna':                         'zero trust network access',
+    'zero trust network':           'zero trust network access',
+
+    # External identities & guests
+    'b2b':                          'external collaboration guest users',
+    'b2c':                          'external identities',
+    'guest':                        'guest users external collaboration',
+    'external user':                'guest users external collaboration',
+    'external identity':            'external identities',
+    'cross-tenant':                 'cross tenant access',
+    'cross tenant':                 'cross tenant access',
+
+    # Applications & service principals
+    'app registration':             'application registration',
+    'app registrations':            'application registration',
+    'app reg':                      'application registration',
+    'service principal':            'enterprise application service principal',
+    'sp':                           'service principal enterprise application',
+    'enterprise app':               'enterprise application',
+    'saml':                         'enterprise application single sign on',
+    'sso':                          'single sign on enterprise application',
+    'single sign-on':               'single sign on enterprise application',
+    'oauth':                        'application permission oauth',
+    'api permission':               'application permission consent',
+    'admin consent':                'application permission consent grant',
+
+    # Entitlement management & governance
+    'elm':                          'entitlement management',
+    'entitlement':                  'entitlement management access package',
+    'access package':               'entitlement management access package',
+    'access packages':              'entitlement management access package',
+    'manage access packages':       'entitlement management access package',
+    'access review':                'access reviews',
+    'lifecycle':                    'lifecycle workflows identity governance',
+    'identity governance':          'entitlement management access reviews',
+
+    # Devices
+    'mdm':                          'mobile device management',
+    'device management':            'mobile device management intune',
+    'intune':                       'mobile device management',
+    'aad join':                     'azure ad join device',
+    'entra join':                   'azure ad join device',
+    'hybrid join':                  'hybrid azure ad joined device',
+    'bitlocker':                    'bitlocker device encryption',
+    'compliance policy':            'device compliance intune',
+
+    # Security & monitoring
+    'defender':                     'microsoft defender security',
+    'identity protection':          'microsoft entra id protection risk',
+    'id protection':                'microsoft entra id protection risk',
+    'risky user':                   'identity protection risk user',
+    'risky sign-in':                'identity protection risk sign in',
+    'sign in log':                  'sign in logs audit',
+    'signin log':                   'sign in logs audit',
+    'audit log':                    'audit logs monitoring',
+    'diagnostic':                   'diagnostic settings monitoring',
+    'siem':                         'security information event management',
+
+    # Directory & users
+    'aad':                          'azure active directory',
+    'azure ad':                     'microsoft entra id',
+    'entra id':                     'microsoft entra id',
+    'directory role':               'directory role assignment',
+    'admin unit':                   'administrative unit',
+    'administrative unit':          'administrative unit',
+    'administrative units':         'administrative unit',
+    'manage administrative units':  'administrative unit',
+    'scoped admin':                 'administrative unit',
+    'au':                           'administrative unit',
+    'bulk user':                    'bulk create import users',
+    'manage groups':                'manage security groups',
+    'dynamic group':                'dynamic membership group',
+    'dynamic membership':           'dynamic membership group',
+    'license':                      'license assignment',
+    'license assignment':           'license assignment',
+
+    # Networking & hybrid
+    'ad connect':                   'azure ad connect hybrid',
+    'azure ad connect':             'azure ad connect hybrid sync',
+    'adc':                          'azure ad connect',
+    'hybrid':                       'hybrid azure ad connect on premises',
+    'on-premises':                  'on premises directory sync',
+    'on prem':                      'on premises directory sync',
+    'password hash sync':           'password hash synchronization azure ad connect',
+    'phs':                          'password hash synchronization',
+    'pts':                          'pass through authentication',
+    'pass-through':                 'pass through authentication',
+    'pta':                          'pass through authentication',
+    'federation':                   'federated identity federation',
+    'adfs':                         'active directory federation services',
+
+    # Misc Entra features
+    'verified id':                  'verifiable credentials',
+    'verifiable credential':        'verifiable credentials',
+    'workload identity':            'workload identity federated credential',
+    'managed identity':             'managed identity workload',
+    'custom domain':                'custom domain name dns',
+    'tenant':                       'tenant settings configuration',
+    'terms of use':                 'terms of use compliance',
+    'tou':                          'terms of use',
+
+    # Agent identity
+    'manage ai agents':             'agent identity',
+    'ai agent management':          'agent identity',
+    'agent management':             'agent identity',
+    'ai agent':                     'agent identity',
+    'copilot agent':                'agent identity',
+    'bot identity':                 'agent identity',
+    'bot':                          'agent identity',
+    'nhi':                          'agent identity',
+    'non-human identity':           'agent identity',
+    'nonhuman identity':            'agent identity',
+    'machine identity':             'agent identity',
+    'agentic identity':             'agent identity',
+    'genai identity':               'agent identity',
+    'llm agent':                    'agent identity',
+    'autonomous agent':             'agent identity',
+    'blueprint':                    'agent identity blueprint',
+    'agent blueprint':              'agent identity blueprint',
+    'agent id':                     'agent identity',
+    'sponsor':                      'agent sponsor',
+    'agent owner':                  'agent sponsor',
+    'agent registry':               'agent registry administrator',
+    'agent rbac':                   'agent id administrator',
+    'govern agents':                'agent id administrator',
+    'service account':              'service principal',
+    'svc account':                  'service principal',
+    'robot account':                'service principal',
+    'nhi governance':               'nonhuman identity',
+    'orphaned agent':               'agent identity',
+    'ownerless agent':              'agent identity',
+    'hybrid identity admin':        'entra connect administrator',
+    'entra connect admin':          'entra connect administrator',
+    'passkey admin':                'authentication administrator',
+    'fido admin':                   'authentication administrator',
+    'external user admin':          'guest inviter',
+    'guest admin':                  'guest inviter',
+    'pim for groups':               'privileged access administrator',
+    'privileged access group':      'privileged access administrator',
+    'eligible group member':        'privileged identity management',
+
+    # AI governance
+    'copilot admin':                'ai administrator',
+    'copilot rbac':                 'ai administrator',
+    'ai rbac':                      'ai administrator',
+    'copilot permissions':          'ai administrator',
+    'copilot governance':           'copilot governance',
+    'm365 copilot admin':           'ai administrator',
+    'ai audit':                     'ai reader',
+    'copilot audit':                'ai reader',
+    'ai read-only':                 'ai reader',
+    'genai admin':                  'ai administrator',
+    'llm admin':                    'ai administrator',
+    'copilot':                      'ai administrator',
+    'm365 copilot':                 'ai administrator',
+    'ai governance':                'ai administrator',
+    'ai admin':                     'ai administrator',
+    'openai admin':                 'ai administrator',
+    'chatgpt admin':                'ai administrator',
+    'ai reader':                    'ai reader',
+    'govern copilot':               'ai administrator',
+
+    # Backup and recovery
+    'backup':                       'entra backup administrator',
+    'entra backup':                 'entra backup administrator',
+    'tenant backup':                'entra backup administrator',
+    'directory backup':             'entra backup administrator',
+    'entra restore':                'entra backup administrator',
+    'tenant restore':               'entra backup administrator',
+    'disaster recovery':            'entra backup administrator',
+    'dr':                           'entra backup administrator',
+    'bcdr':                         'entra backup administrator',
+    'recover deleted':              'entra backup administrator',
+    'undelete':                     'entra backup administrator',
+    'rollback':                     'entra backup administrator',
+    'recovery':                     'entra backup administrator',
+    'backup admin':                 'entra backup administrator',
+    'entra dr':                     'entra backup administrator',
+    'restore entra':                'entra backup administrator',
+    'recover deleted users':        'entra backup administrator',
+    'recover deleted groups':       'entra backup administrator',
+
+    # GDAP and tenant governance
+    'gdap':                         'tenant governance administrator',
+    'granular delegated admin':     'tenant governance administrator',
+    'csp admin':                    'tenant governance administrator',
+    'msp admin':                    'tenant governance administrator',
+    'partner access':               'tenant governance administrator',
+    'delegated admin':              'tenant governance administrator',
+    'dap':                          'tenant governance administrator',
+    'customer tenant':              'tenant governance administrator',
+    'managing customer tenants':    'tenant governance administrator',
+    'gdap relationship':            'tenant governance relationship administrator',
+    'csp':                          'tenant governance',
+    'partner delegation':           'tenant governance',
+
+    # Shadow / unlisted roles
+    'hidden roles':                 'shadow role',
+    'undocumented roles':           'shadow role',
+    'new roles':                    'shadow role',
+    'secret roles':                 'shadow role',
+    'stealth roles':                'shadow role',
+    'graph only':                   'shadow role',
+    'missing from docs':            'shadow role',
+    'not in docs':                  'shadow role',
+    'unlisted roles':               'shadow role',
+    'unlisted':                     'shadow role',
+
+    # Agent assignability
+    'role for agent':               'agent assignable',
+    'agent compatible':             'agent assignable',
+    'agent restrictions':           'agent blocked roles',
+    'blocked for agents':           'agent blocked roles',
+}
+
+# Build reverse map: every word in any expansion value → canonical expansion
+_REVERSE_SYNONYMS: dict[str, str] = {}
+for _key, _expansion in SYNONYMS.items():
+    _REVERSE_SYNONYMS[_key.lower()] = _expansion
+    for _word in _expansion.split():
+        if len(_word) >= 3 and _word not in _REVERSE_SYNONYMS:
+            _REVERSE_SYNONYMS[_word.lower()] = _expansion
+
+
+def expand_query(input_query: str) -> str:
+    """Mirror of the JS expandQuery() in index.html."""
+    lower = input_query.lower().strip()
+
+    # 1. Exact key match
+    if lower in SYNONYMS:
+        return SYNONYMS[lower]
+
+    # 2. Key contained within input (whole-word boundary match)
+    for key, expansion in SYNONYMS.items():
+        pattern = re.compile(
+            r'\b' + re.escape(key) + r'\b',
+            re.IGNORECASE,
+        )
+        if pattern.search(lower):
+            return pattern.sub(expansion, lower)
+
+    # 3. Any word in the input matches a reverse-synonym
+    for word in lower.split():
+        if word in _REVERSE_SYNONYMS:
+            return _REVERSE_SYNONYMS[word]
+
+    # 4. No match — return original
+    return input_query

--- a/pipeline/test_pills.py
+++ b/pipeline/test_pills.py
@@ -13,6 +13,8 @@ from urllib.parse import quote
 
 import requests
 
+from synonyms import expand_query
+
 WORKER_URL = os.environ.get(
     "WORKER_URL",
     "https://rolelens-worker.russo-antonio76.workers.dev",
@@ -41,7 +43,8 @@ EXPECTATIONS: list[tuple[str, str]] = [
 
 def run_pill(query: str, expected_role: str) -> tuple[bool, str]:
     """Returns (passed, detail_message)."""
-    url = f"{WORKER_URL}/api/search?q={quote(query)}"
+    expanded = expand_query(query)
+    url = f"{WORKER_URL}/api/search?q={quote(expanded)}"
     try:
         resp = requests.get(url, timeout=10)
     except requests.RequestException as exc:
@@ -67,7 +70,9 @@ def main() -> int:
     for query, expected in EXPECTATIONS:
         passed, detail = run_pill(query, expected)
         marker = "PASS" if passed else "FAIL"
-        print(f"  {marker}  {query!r:45s}  {detail}")
+        expanded = expand_query(query)
+        suffix = f" [-> {expanded!r}]" if expanded != query else ""
+        print(f"  {marker}  {query!r:45s}  {detail}{suffix}")
         if not passed:
             failures.append(f"  - {query!r}: {detail}")
 


### PR DESCRIPTION
## Summary

- Adds `pipeline/synonyms.py` — a faithful Python port of the `SYNONYMS` dict and `expandQuery()` logic from `index.html` (220 entries)
- Updates `pipeline/test_pills.py` to call `expand_query()` before each API request so CI tests mirror the actual user path through the frontend
- Print output now shows `[-> 'expanded query']` when expansion fires

## Baseline

| Before (raw queries) | After (with expansion) |
|---|---|
| 9/15 passing | 10/15 passing |

The 5 remaining failures expose real expansion bugs in the synonym dict that affect the live frontend for queries like `restore deleted users` (reverse-synonym false positive on `users` → guest expansion) and `GDAP relationships`. These are tracked for Week 2 BM25 / synonym refinement work.

## Test plan
- [ ] Verify `python pipeline/test_pills.py` runs without import errors
- [ ] Confirm 10/15 baseline in Actions log after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)