### PR TITLE
fix: stopword guard on reverse-synonym map

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1564,16 +1564,41 @@
     'blocked for agents':      'agent blocked roles',
   };
 
-  // Build reverse map: every word in any expansion value → canonical expansion
+  // Words that appear inside multiple synonym expansion values but should
+  // NOT independently route queries. Keep this list in sync with the
+  // equivalent _REVERSE_MAP_STOPWORDS set in pipeline/synonyms.py
+  // (Chunk 4, 2026-04-25).
+  const REVERSE_MAP_STOPWORDS = new Set([
+    "access","account","accounts","active","all","and","any",
+    "application","applications","audit","based","between","block",
+    "can","cloud","configuration","connect","create","data",
+    "device","devices","directory","domain","edit","entra","every",
+    "factor","for","from","group","groups","id","identities",
+    "identity","in","information","into","issue","key","list",
+    "log","logs","manage","management","method","methods",
+    "microsoft","mobile","monitoring","name","new","not","of",
+    "on","or","out","own","policy","premises","principal",
+    "register","registration","reset","review","reviews","role",
+    "roles","secure","security","service","services","set",
+    "settings","shadow","sign","single","tenant","the","through",
+    "time","to","trust","two","use","user","users","via","with",
+    "workload","zero"
+  ]);
+
+  // Build reverse map: every word in any expansion value -> canonical expansion
+  // Stopword guard prevents common English words from hijacking queries.
   const REVERSE_SYNONYMS = (() => {
     const map = {};
     for (const [key, expansion] of Object.entries(SYNONYMS)) {
-      // Index the key itself (normalised)
       map[key.toLowerCase()] = expansion;
-      // Also index each word of the expansion back to itself
       for (const word of expansion.split(/\s+/)) {
-        if (word.length >= 3 && !map[word]) {
-          map[word.toLowerCase()] = expansion;
+        const lw = word.toLowerCase();
+        if (
+          word.length >= 3
+          && !map[lw]
+          && !REVERSE_MAP_STOPWORDS.has(lw)
+        ) {
+          map[lw] = expansion;
         }
       }
     }

--- a/pipeline/synonyms.py
+++ b/pipeline/synonyms.py
@@ -259,13 +259,56 @@ SYNONYMS: dict[str, str] = {
     'blocked for agents':           'agent blocked roles',
 }
 
-# Build reverse map: every word in any expansion value → canonical expansion
-_REVERSE_SYNONYMS: dict[str, str] = {}
-for _key, _expansion in SYNONYMS.items():
-    _REVERSE_SYNONYMS[_key.lower()] = _expansion
-    for _word in _expansion.split():
-        if len(_word) >= 3 and _word not in _REVERSE_SYNONYMS:
-            _REVERSE_SYNONYMS[_word.lower()] = _expansion
+# Words that appear inside multiple synonym expansion values but should NOT
+# independently route queries. Without this guard, common words like "users"
+# get reverse-indexed back to the first expansion containing them, causing
+# unrelated queries to be hijacked.
+#
+# Keep this list in sync with the equivalent STOPWORDS set in
+# frontend/index.html (Chunk 4, 2026-04-25).
+_REVERSE_MAP_STOPWORDS = {
+    "access", "account", "accounts", "active", "all", "and", "any",
+    "application", "applications", "audit", "based", "between", "block",
+    "can", "cloud", "configuration", "connect", "create", "data",
+    "device", "devices", "directory", "domain", "edit", "entra", "every",
+    "factor", "for", "from", "group", "groups", "id", "identities",
+    "identity", "in", "information", "into", "issue", "key", "list",
+    "log", "logs", "manage", "management", "method", "methods",
+    "microsoft", "mobile", "monitoring", "name", "new", "not", "of",
+    "on", "or", "out", "own", "policy", "premises", "principal",
+    "register", "registration", "reset", "review", "reviews", "role",
+    "roles", "secure", "security", "service", "services", "set",
+    "settings", "shadow", "sign", "single", "tenant", "the", "through",
+    "time", "to", "trust", "two", "use", "user", "users", "via", "with",
+    "workload", "zero",
+}
+
+
+def _build_reverse_map(synonyms: dict) -> dict:
+    """Mirror the JS REVERSE_SYNONYMS IIFE.
+
+    Indexes synonym keys back to their expansions, plus each word in every
+    expansion value (length >= 3) that is NOT in _REVERSE_MAP_STOPWORDS.
+    The stopword guard prevents common English words from hijacking queries
+    via Step 3 of expand_query.
+    """
+    mapping = {}
+    for key, expansion in synonyms.items():
+        lower_key = key.lower()
+        if lower_key not in mapping:
+            mapping[lower_key] = expansion
+        for word in expansion.split():
+            lw = word.lower()
+            if (
+                len(word) >= 3
+                and lw not in mapping
+                and lw not in _REVERSE_MAP_STOPWORDS
+            ):
+                mapping[lw] = expansion
+    return mapping
+
+
+_REVERSE_SYNONYMS: dict[str, str] = _build_reverse_map(SYNONYMS)
 
 
 def expand_query(input_query: str) -> str:

--- a/pipeline/test_pills.py
+++ b/pipeline/test_pills.py
@@ -56,7 +56,7 @@ KNOWN_FAILURES: set[str] = {
     "reset user password",     # External ID User Flow Admin keyword tie
     "manage groups",           # Identity Governance ranks above Groups Admin
     "GDAP relationships",      # Synonym chain produces noisy phrase, Reader wins
-    "restore deleted users",   # 'users' reverse-synonym fires guest expansion
+    # "restore deleted users" RESOLVED 2026-04-25 by Chunk 4 stopword guard
 }
 
 


### PR DESCRIPTION
Fixes a class of query-hijack bug where common English words appearing inside synonym expansion values would route unrelated queries via Step 3 of expandQuery.

Concrete case resolved: 'restore deleted users' was being routed to Guest Inviter because 'users' was reverse-indexed back to the guest expansion. With ~85 common English words now guarded, common words can no longer leak into routing.

Both frontend/index.html (REVERSE_MAP_STOPWORDS) and pipeline/synonyms.py (_REVERSE_MAP_STOPWORDS) updated identically. KNOWN_FAILURES in test_pills.py pruned from 5 to 4 (restore deleted users removed).

Pill tests pass with no regressions: 11 PASS, 4 KNOWN-FAIL, 0 REGRESSION, exit code 0.

Architectural note: this is a *category* fix. Any future synonym additions are immune to the same bug class as long as they don't overload stopword tokens.