### PR TITLE
feat: BM25 ranking infrastructure (Stage 1 - not promoted, A/B gated)

### DIFF
--- a/pipeline/compare_rankers.py
+++ b/pipeline/compare_rankers.py
@@ -1,0 +1,142 @@
+"""
+compare_rankers.py — A/B comparison harness for BM25 vs keyword ranker.
+
+Runs representative queries against the worker's debug=compare endpoint,
+reports agreement/disagreement, and provides data for a promotion decision.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import quote
+
+import requests
+
+WORKER_URL = os.environ.get(
+    "WORKER_URL",
+    "https://rolelens-worker.russo-antonio76.workers.dev",
+)
+
+# 30 queries covering categorical breadth.
+# 10 placeholder slots for user-added queries from real usage instinct.
+COMPARISON_QUERIES = [
+    # All 15 documented pills (matches test_pills.py expectations)
+    "configure passkeys",
+    "backup",
+    "reset password",
+    "reset user password",
+    "manage conditional access",
+    "configure SSPR",
+    "manage AI agents",
+    "manage groups",
+    "manage administrative units",
+    "manage Copilot governance",
+    "GDAP relationships",
+    "restore deleted users",
+    "audit AI usage",
+    "configure PIM",
+    "approve access review",
+    # Verb + noun (common patterns)
+    "create user",
+    "delete role",
+    "view audit logs",
+    "assign license",
+    "invite guest user",
+    # Acronyms (single-word queries)
+    "FIDO2",
+    "MFA",
+    "PIM",
+    "GSA",
+    "SSPR",
+    # Multi-word topic queries
+    "named locations conditional access",
+    "service principal management",
+    "cross tenant access settings",
+    "verifiable credentials",
+    "self-service password reset configuration",
+
+    # USER-ADDED QUERIES — Antonio adds 10 here based on real usage:
+    # "<your query 1>",
+    # ...
+]
+
+
+def run_compare(query: str) -> dict | None:
+    url = f"{WORKER_URL}/api/search?q={quote(query)}&debug=compare"
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:
+        print(f"  ERROR for {query!r}: {exc}", file=sys.stderr)
+        return None
+
+
+def main() -> int:
+    print(f"A/B comparison: {len(COMPARISON_QUERIES)} queries")
+    print(f"Endpoint: {WORKER_URL}")
+    print("=" * 100)
+
+    agree_count = 0
+    disagree = []
+    bm25_empty = []
+    keyword_empty = []
+    both_empty = 0
+    errors = 0
+
+    for query in COMPARISON_QUERIES:
+        result = run_compare(query)
+        if result is None:
+            errors += 1
+            continue
+
+        kw_top   = result.get("keyword_ranker", {}).get("top_5", [])
+        bm25_top = result.get("bm25_ranker",    {}).get("top_5", [])
+        kw_role   = kw_top[0]["min_role"]   if kw_top   else None
+        bm25_role = bm25_top[0]["min_role"] if bm25_top else None
+
+        if kw_role == bm25_role and kw_role is not None:
+            agree_count += 1
+            print(f"  AGREE      {query!r:48s} -> {kw_role}")
+        elif not kw_top and not bm25_top:
+            both_empty += 1
+            print(f"  BOTH EMPTY {query!r:48s}")
+        elif not bm25_top:
+            bm25_empty.append(query)
+            print(f"  BM25 EMPTY {query!r:48s} (kw: {kw_role})")
+        elif not kw_top:
+            keyword_empty.append(query)
+            print(f"  KW EMPTY   {query!r:48s} (bm25: {bm25_role})")
+        else:
+            disagree.append({
+                "query":      query,
+                "keyword":    kw_role,
+                "bm25":       bm25_role,
+                "kw_score":   kw_top[0].get("score"),
+                "bm25_score": bm25_top[0].get("score"),
+            })
+            print(f"  DISAGREE   {query!r:48s}")
+            print(f"       kw:   {kw_role} ({kw_top[0].get('score', 0):.1f})")
+            print(f"       bm25: {bm25_role} ({bm25_top[0].get('score', 0):.1f})")
+
+    print("=" * 100)
+    print(f"Total queries:     {len(COMPARISON_QUERIES)}")
+    print(f"Agree:             {agree_count}")
+    print(f"Disagree:          {len(disagree)}")
+    print(f"BM25 empty:        {len(bm25_empty)}")
+    print(f"Keyword empty:     {len(keyword_empty)}")
+    print(f"Both empty:        {both_empty}")
+    print(f"Errors:            {errors}")
+
+    if disagree:
+        print("\nDisagreements (review carefully):")
+        for d in disagree:
+            print(f"  {d['query']!r}")
+            print(f"    keyword: {d['keyword']} ({d['kw_score']:.1f})")
+            print(f"    bm25:    {d['bm25']} ({d['bm25_score']:.1f})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -109,10 +109,42 @@ function badRequest(msg: string): Response {
 }
 
 // ---------------------------------------------------------------------------
+// Corpus stats cache (BM25)
+// ---------------------------------------------------------------------------
+
+interface CorpusStats {
+  total_docs: number;
+  avg_doc_length: number;
+}
+
+// Loaded once per worker isolate. Refreshes on isolate recycle or deploy.
+// Staleness is acceptable because corpus_stats only updates nightly.
+let _corpusStatsCache: CorpusStats | null = null;
+
+async function getCorpusStats(env: Env): Promise<CorpusStats> {
+  if (_corpusStatsCache) return _corpusStatsCache;
+
+  const result = await env.DB.prepare(
+    `SELECT key, value FROM corpus_stats`
+  ).all();
+
+  // Safe defaults match measured values so BM25 stays sensible on cache miss.
+  const stats: CorpusStats = { total_docs: 237, avg_doc_length: 6.0 };
+
+  for (const row of result.results ?? []) {
+    if (row.key === "total_docs")     stats.total_docs     = Number(row.value);
+    if (row.key === "avg_doc_length") stats.avg_doc_length = Number(row.value);
+  }
+
+  _corpusStatsCache = stats;
+  return stats;
+}
+
+// ---------------------------------------------------------------------------
 // Search helpers
 // ---------------------------------------------------------------------------
 
-type MatchType = "exact" | "full_keyword" | "partial";
+type MatchType = "exact" | "full_keyword" | "partial" | "bm25";
 type Entry = { row: Record<string, unknown>; matchType: MatchType };
 
 // Run all three keyword queries (phrase, full-AND, partial-OR) in parallel
@@ -192,6 +224,57 @@ async function runKeywordTier(
   return merged;
 }
 
+// ── BM25 ranking tier ─────────────────────────────────────────────────────
+// Smoothed Okapi BM25 (k1=1.2, b=0.5).
+// b reduced from standard 0.75 because corpus has short docs (avg ~6 tokens).
+const BM25_K1 = 1.2;
+const BM25_B  = 0.5;
+
+async function runBM25Tier(
+  env: Env,
+  kws: string[],
+): Promise<Map<string, Entry>> {
+  if (kws.length === 0) return new Map();
+
+  const corpus = await getCorpusStats(env);
+  const avgdl  = corpus.avg_doc_length;
+  const k1     = BM25_K1;
+  const b      = BM25_B;
+
+  const ph = kws.map(() => "?").join(",");
+
+  // Per-task sum of per-keyword BM25 contributions * 100 keeps base_score
+  // magnitude comparable to existing tiers after privilegeFactor multiplies.
+  const sql = `
+    SELECT t.id, t.task_description, t.feature_area,
+           t.alt_role_ids, t.source_url,
+           r.id AS min_role_id, r.display_name AS min_role_name,
+           r.is_privileged, r.permissions,
+           SUM(
+             ts.idf *
+             (ts.tf * (${k1} + 1)) /
+             (ts.tf + ${k1} * (1 - ${b} + ${b} * COALESCE(t.doc_length, ${avgdl}) / ${avgdl}))
+           ) * 100 AS base_score
+    FROM task_search ts
+    JOIN tasks t ON ts.task_id = t.id
+    JOIN roles r ON t.min_role_id = r.id
+    WHERE ts.keyword IN (${ph})
+      AND ts.idf IS NOT NULL
+      AND t.out_of_scope IS NULL
+    GROUP BY t.id
+    ORDER BY base_score DESC
+    LIMIT 20
+  `;
+
+  const result = await env.DB.prepare(sql).bind(...kws).all();
+
+  const map = new Map<string, Entry>();
+  for (const row of (result.results ?? []) as Record<string, unknown>[]) {
+    map.set(String(row.id), { row, matchType: "bm25" });
+  }
+  return map;
+}
+
 // LIKE-only fallback — uses longest meaningful topic keyword (≥5 chars),
 // falling back to the full query phrase if none qualifies.
 // This prevents short generic words like "access" from matching unrelated tasks.
@@ -228,6 +311,7 @@ async function runLikeTier(
 }
 
 function applyAffinityAndScore(seen: Map<string, Entry>): unknown[] {
+  if (seen.size === 0) return [];
   const scored = [...seen.values()].map(({ row, matchType }) => {
     const permCount = safeParseJson(row.permissions as string, []).length;
     const isPriv    = row.is_privileged === 1;
@@ -285,23 +369,76 @@ function applyAffinityAndScore(seen: Map<string, Entry>): unknown[] {
 // Route handlers
 // ---------------------------------------------------------------------------
 
+function extractKeywordsForSearch(q: string): {
+  keywords: string[];
+  topicKeywords: string[];
+  sqKeywords: string[];
+} {
+  const keywords      = extractKeywords(q);
+  const topicKeywords = keywords.filter((k) => !GENERIC_VERBS.has(k));
+  const sqKeywords    = topicKeywords.length > 0 ? topicKeywords : keywords;
+  return { keywords, topicKeywords, sqKeywords };
+}
+
+async function handleSearchCompare(
+  env: Env,
+  q: string,
+): Promise<Response> {
+  const { keywords, topicKeywords, sqKeywords } = extractKeywordsForSearch(q);
+
+  const [keywordMap, bm25Map] = await Promise.all([
+    runKeywordTier(env, q, sqKeywords),
+    runBM25Tier(env, sqKeywords),
+  ]);
+
+  const keywordResults = applyAffinityAndScore(keywordMap) as any[];
+  const bm25Results    = applyAffinityAndScore(bm25Map)    as any[];
+
+  return json({
+    query:          q,
+    keywords,
+    topic_keywords: topicKeywords,
+    keyword_ranker: {
+      count: keywordResults.length,
+      top_5: keywordResults.slice(0, 5).map((r) => ({
+        task:       r.task,
+        min_role:   r.min_role,
+        score:      r.score,
+        match_type: r.match_type,
+      })),
+    },
+    bm25_ranker: {
+      count: bm25Results.length,
+      top_5: bm25Results.slice(0, 5).map((r) => ({
+        task:       r.task,
+        min_role:   r.min_role,
+        score:      r.score,
+        match_type: r.match_type,
+      })),
+    },
+    same_top_role:
+      keywordResults[0]?.min_role != null &&
+      keywordResults[0]?.min_role === bm25Results[0]?.min_role,
+  });
+}
+
 async function handleSearch(url: URL, env: Env): Promise<Response> {
   const q = url.searchParams.get("q")?.trim() ?? "";
   if (!q) return badRequest("Missing or empty query parameter: q");
 
-  const keywords = extractKeywords(q);
+  // Internal A/B endpoint — not part of normal search flow.
+  if (url.searchParams.get("debug") === "compare") {
+    return handleSearchCompare(env, q);
+  }
+
+  const { keywords, topicKeywords, sqKeywords } = extractKeywordsForSearch(q);
   if (keywords.length === 0) return json([]);
 
-  const topicKeywords = keywords.filter((k) => !GENERIC_VERBS.has(k));
-  const sqKeywords    = topicKeywords.length > 0 ? topicKeywords : keywords;
-
-  // FIX 1 — Three-tier fallback:
   // Tier 1: topic keywords only (precise, avoids "configure" noise)
   const tier1 = await runKeywordTier(env, q, sqKeywords);
   if (tier1.size > 0) return json(applyAffinityAndScore(tier1));
 
-  // Tier 2: all keywords including generic verbs (only runs if tier 1 empty
-  //         AND there are generic verbs that were stripped)
+  // Tier 2: all keywords including generic verbs (only if some were stripped)
   if (topicKeywords.length < keywords.length) {
     const tier2 = await runKeywordTier(env, q, keywords);
     if (tier2.size > 0) return json(applyAffinityAndScore(tier2));


### PR DESCRIPTION
## Summary

- Deploys BM25 ranking tier to the worker as non-default infrastructure
- Adds `/api/search?q=X&debug=compare` endpoint for side-by-side ranker comparison
- Adds `pipeline/compare_rankers.py` A/B harness for future promotion decisions
- Default search routing unchanged â€” users see no behaviour change

## Changes

**`worker/src/index.ts`**
- `getCorpusStats()` â€” isolate-level cache for `corpus_stats` D1 table (total_docs, avg_doc_length)
- `runBM25Tier()` â€” smoothed Okapi BM25 (k1=1.2, b=0.5; b reduced for short-doc corpus)
- `handleSearchCompare()` â€” runs both rankers in parallel, returns side-by-side JSON
- `extractKeywordsForSearch()` â€” helper extracted from `handleSearch` so both functions share keyword logic
- `applyAffinityAndScore()` â€” added empty-map guard (was unreachable in normal flow; exposed by compare endpoint)
- `handleSearch` â€” intercepts `?debug=compare` before normal tier routing

**`pipeline/compare_rankers.py`** (new)
- 30-query comparison harness against the debug endpoint
- Categorised output: AGREE / DISAGREE / BM25-EMPTY / KW-EMPTY / BOTH-EMPTY
- Reusable for future promotion decisions or parameter tuning

## A/B comparison results

30 representative queries tested against both rankers:

```
23 agree / 4 disagree / 1 BM25-empty / 2 both-empty / 0 errors
```

Disagreements:

| Query | Keyword | BM25 | Verdict |
|---|---|---|---|
| `reset password` | Password Administrator âœ“ | Authentication Policy Administrator | BM25 regresses |
| `reset user password` | Password Administrator âœ“ | External ID User Flow Administrator | BM25 regresses |
| `create user` | User Administrator âœ“ | Guest Inviter | BM25 picks wrong role |
| `service principal management` | Agent ID Developer (score 2.8) | Identity Governance Administrator | Both weak |

## Why BM25 was not promoted

The 4 KNOWN_FAILURES (`reset password`, `reset user password`, `manage groups`, `GDAP relationships`) are **synonym-expansion artifacts**, not ranking bugs. The pipeline's `synonyms.py` rewrites these queries before they reach the ranker â€” BM25 never sees the original terms and therefore cannot fix the symptom.

Additionally, BM25 regresses `create user` â†’ Guest Inviter (clearly wrong) and both password-reset queries. Promotion would introduce new regressions without resolving the known failures.

## Next steps

The root cause of the 4 KNOWN_FAILURES is in synonym routing. Correct fix: audit which synonym expansions are causing the wrong queries to reach the worker, then either narrow the synonym triggers or adjust the expanded terms. BM25 infrastructure stays in place for future promotion once that investigation is complete.

## Pill tests

```
PASS: 11 / KNOWN-FAIL: 4 / REGRESSION: 0
```

Identical to pre-chunk baseline. Worker already deployed at version `1581235d`.

Foundation: BM25 stats from Chunk 6a (PR #21).
