### PR TITLE
Add Trivy security scanning workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # Node.js deps (Worker)
+  - package-ecosystem: npm
+    directory: /worker
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Zurich
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - npm
+
+  # Python deps (Pipeline)
+  - package-ecosystem: pip
+    directory: /pipeline
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Zurich
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - pip
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Zurich
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -17,6 +17,11 @@ jobs:
       id-token: write # MANDATORY: Allows GitHub to request the OIDC token from Entra
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Checkout repo
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,41 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "0 5 * * 1" # Weekly Monday 05:00 UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    name: Scorecard
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # For SARIF upload
+      security-events: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true # Publish to OpenSSF REST API
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: scorecard-results.sarif
+          category: scorecard

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -25,6 +25,11 @@ jobs:
           - worker    # Node.js (package.json + lockfile)
           - pipeline  # Python (requirements.txt)
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v4
 
       - name: Trivy fs scan (${{ matrix.path }})
@@ -48,6 +53,11 @@ jobs:
     name: Config Scan
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v4
 
       - name: Trivy config scan
@@ -73,6 +83,11 @@ jobs:
     name: SBOM
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v4
 
       - name: Generate SBOM (worker)

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,101 @@
+name: Trivy Security Scan
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "0 6 * * 0" # Weekly Sunday 06:00 UTC
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: read
+  security-events: write # For SARIF upload
+
+jobs:
+  # ── Dependency vulnerability scan (filesystem) ──
+  vuln-scan:
+    name: Vuln Scan
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        path:
+          - worker    # Node.js (package.json + lockfile)
+          - pipeline  # Python (requirements.txt)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trivy fs scan (${{ matrix.path }})
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: ${{ matrix.path }}
+          format: sarif
+          output: trivy-vuln-${{ matrix.path }}.sarif
+          severity: HIGH,CRITICAL
+          exit-code: 0 # Report but don't fail
+
+      - name: Upload vuln SARIF (${{ matrix.path }})
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-vuln-${{ matrix.path }}.sarif
+          category: trivy-vuln-${{ matrix.path }}
+
+  # ── Misconfiguration scan ──
+  config-scan:
+    name: Config Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trivy config scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: config
+          scan-ref: .
+          format: sarif
+          output: trivy-config.sarif
+          severity: HIGH,CRITICAL
+          exit-code: 0
+          # Scan for Dockerfile, K8s, Terraform, CloudFormation misconfigs
+          # wrangler.toml is also checked for misconfigurations
+
+      - name: Upload config SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config
+
+  # ── SBOM generation ──
+  sbom:
+    name: SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate SBOM (worker)
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: worker
+          format: cyclonedx
+          output: sbom-worker.json
+
+      - name: Generate SBOM (pipeline)
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: pipeline
+          format: cyclonedx
+          output: sbom-pipeline.json
+
+      - name: Upload SBOMs as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sboms
+          path: |
+            sbom-worker.json
+            sbom-pipeline.json
+          retention-days: 90

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Trivy fs scan (${{ matrix.path }})
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: fs
           scan-ref: ${{ matrix.path }}
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Trivy config scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: config
           scan-ref: .
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Generate SBOM (worker)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: fs
           scan-ref: worker
@@ -99,7 +99,7 @@ jobs:
           output: sbom-worker.json
 
       - name: Generate SBOM (pipeline)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: fs
           scan-ref: pipeline

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       # ── 1. Checkout ────────────────────────────────────────────────────────
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## What

Adds a comprehensive Trivy security scanning workflow covering:

### Scans
- **Vulnerability scan** — checks Node.js deps (worker/) and Python deps (pipeline/) for known CVEs (HIGH/CRITICAL)
- **Misconfiguration scan** — checks Dockerfiles, K8s manifests, Terraform, IaC configs, wrangler.toml
- **SBOM generation** — CycloneDX SBOM for both worker and pipeline, retained 90 days

### Triggers
- Push to master
- Pull requests to master
- Weekly schedule (Sunday 06:00 UTC)
- Manual trigger (workflow_dispatch)

### Output
- SARIF results uploaded to **GitHub Security → Code Scanning** tab
- SBOM artifacts downloadable from Actions runs

### Cost
- **$0** — Trivy is OSS, GitHub Actions is unlimited for public repos

Once this is merged, I'll replicate to Entra-Tracker and AADSTS-Entra-Errors.