### PR TITLE
feat: /api/quality endpoint for Sentrux metrics

### DIFF
--- a/pipeline/push_to_cloudflare.py
+++ b/pipeline/push_to_cloudflare.py
@@ -530,6 +530,59 @@ def update_readme_data_quality(master_path: Path, readme_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Push: Sentrux metrics to D1
+# ---------------------------------------------------------------------------
+
+def push_sentrux_metrics(account_id: str, database_id: str, token: str) -> None:
+    """Push Sentrux quality metrics from .sentrux/quality.json to D1.
+
+    Writes to sentrux_metrics(key TEXT PK, value TEXT). All values stored as
+    strings for uniform type handling; the worker parses them back on read.
+
+    Silently skips if quality.json is missing or contains an error field --
+    Sentrux failures must not break the pipeline.
+    """
+    quality_file = Path(__file__).parent.parent / ".sentrux" / "quality.json"
+
+    if not quality_file.exists():
+        print("  Sentrux quality.json missing — skipping D1 push")
+        return
+
+    try:
+        with open(quality_file, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"  Sentrux quality.json unreadable ({exc}) — skipping D1 push")
+        return
+
+    if data.get("error") or data.get("quality") is None:
+        print("  Sentrux quality has error or null score — skipping D1 push")
+        return
+
+    rows = {
+        "quality":                  data.get("quality"),
+        "baseline":                 data.get("baseline"),
+        "coupling_current":         data.get("coupling_current"),
+        "coupling_baseline":        data.get("coupling_baseline"),
+        "cycles_current":           data.get("cycles_current"),
+        "cycles_baseline":          data.get("cycles_baseline"),
+        "god_files_current":        data.get("god_files_current"),
+        "god_files_baseline":       data.get("god_files_baseline"),
+        "main_sequence_distance":   data.get("main_sequence_distance"),
+        "verdict":                  data.get("verdict"),
+        "timestamp":                data.get("timestamp"),
+    }
+
+    sql = "INSERT OR REPLACE INTO sentrux_metrics (key, value) VALUES (?, ?)"
+    statements = [
+        {"sql": sql, "params": [k, "" if v is None else str(v)]}
+        for k, v in rows.items()
+    ]
+    d1_run_many(account_id, database_id, token, statements, "sentrux_metrics")
+    print(f"  Sentrux metrics pushed to D1: quality={rows['quality']}")
+
+
+# ---------------------------------------------------------------------------
 # README Sentrux quality -- backed by SVG dashboard
 # ---------------------------------------------------------------------------
 
@@ -577,6 +630,7 @@ def main() -> None:
     push_tasks(account_id, database_id, api_token, master["tasks"], role_index)
     push_task_search(account_id, database_id, api_token)
     push_changelog(account_id, database_id, api_token, changelog)
+    push_sentrux_metrics(account_id, database_id, api_token)
     readme_path = Path(__file__).parent.parent / "README.md"
     update_readme_whats_new(CHANGELOG_PATH, readme_path)
     update_readme_data_quality(MASTER_PATH, readme_path)

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -538,6 +538,33 @@ async function handleRoles(env: Env): Promise<Response> {
   );
 }
 
+async function handleQuality(env: Env): Promise<Response> {
+  const result = await env.DB.prepare(
+    "SELECT key, value FROM sentrux_metrics"
+  ).all();
+
+  const INT_KEYS = new Set([
+    "quality", "baseline",
+    "cycles_current", "cycles_baseline",
+    "god_files_current", "god_files_baseline",
+  ]);
+  const FLOAT_KEYS = new Set([
+    "coupling_current", "coupling_baseline",
+    "main_sequence_distance",
+  ]);
+
+  const metrics: Record<string, unknown> = {};
+  for (const row of result.results ?? []) {
+    const key   = row.key   as string;
+    const value = row.value as string;
+    if (INT_KEYS.has(key))   metrics[key] = parseInt(value, 10);
+    else if (FLOAT_KEYS.has(key)) metrics[key] = parseFloat(value);
+    else metrics[key] = value;
+  }
+
+  return json({ metrics, has_data: Object.keys(metrics).length > 0 });
+}
+
 async function handleStatus(env: Env): Promise<Response> {
   const value = await env.KV.get("pipeline_status");
   if (value === null) {
@@ -584,6 +611,7 @@ export default {
     const url  = new URL(request.url);
     const path = url.pathname;
 
+    if (path === "/api/quality") return handleQuality(env);
     if (path === "/api/status") return handleStatus(env);
     if (path === "/api/roles")  return handleRoles(env);
     if (path === "/api/search") return handleSearch(url, env);


### PR DESCRIPTION
Adds D1 storage and a worker endpoint for Sentrux quality metrics. No user-visible change -- foundation for a future frontend banner (Chunk C).

## Changes

**D1 schema**
- New `sentrux_metrics(key TEXT PRIMARY KEY, value TEXT)` table
- Seeded with current metrics (quality=7005, baseline=7003, coupling=0.0, cycles=0, god_files=0, distance=0.25) via wrangler direct; nightly pipeline overwrites on each run

**`pipeline/push_to_cloudflare.py`**
- `push_sentrux_metrics()` reads `.sentrux/quality.json` and writes 11 rows to D1 via `d1_run_many()`, called from `main()` after `push_changelog()`
- Silently skips if `quality.json` is missing, unreadable, or contains a null/error quality score

**`worker/src/index.ts`**
- `handleQuality()` reads `sentrux_metrics`, deserialises numeric fields (6 integers, 3 floats, 2 strings) back from TEXT storage
- Returns `{ metrics: {...}, has_data: boolean }`
- New route: `GET /api/quality`

## Verification

- Worker dry-run clean, deployed at version `05f9551c`
- `/api/quality` returns `has_data: true` with all 11 typed fields and correct numeric types
- `/api/status` unchanged and working
- Pill tests 11/4/0/0
- `push_to_cloudflare.py` compiles, exactly one `def main()`

## Foundation

- Chunk A (PR #25) -- animated SVG dashboard and Sentrux parser
- Next: Chunk C -- frontend banner consuming `/api/quality`
