### PR TITLE
fix: resolve 4 KNOWN_FAILURES via surgical synonym edits + regression automation

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -110,6 +110,12 @@ jobs:
         env:
           WORKER_URL: https://rolelens-worker.russo-antonio76.workers.dev
 
+      - name: Synonym expansion regression check
+        continue-on-error: true
+        run: python pipeline/test_synonym_regression.py
+        env:
+          WORKER_URL: https://rolelens-worker.russo-antonio76.workers.dev
+
       # Only fires when test_pills.py exits 1, which now means a NEW
       # regression rather than any failure. Known failures are
       # suppressed via KNOWN_FAILURES in pipeline/test_pills.py.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1382,8 +1382,9 @@
     'passwordless':            'passwordless authentication',
     'sspr':                    'self service password reset',
     'self-service password':   'self service password reset',
-    'password reset':          'self service password reset',
-    'reset user password':     'reset user account password',
+    'password reset':          'reset user password',
+    'reset password':         'reset non admin password',
+    'reset user password':     'reset non admin password',
     'tap':                     'temporary access pass',
     'temporary access pass':   'temporary access pass',
     'windows hello':           'passwordless authentication',
@@ -1469,7 +1470,7 @@
     'scoped admin':            'administrative unit',
     'au':                      'administrative unit',
     'bulk user':               'bulk create import users',
-    'manage groups':           'manage security groups',
+    'manage groups':           'group membership management',
     'dynamic group':           'dynamic membership group',
     'dynamic membership':      'dynamic membership group',
     'license':                 'license assignment',
@@ -1582,6 +1583,7 @@
     'recover deleted groups':  'entra backup administrator',
 
     // GDAP and tenant governance
+    'gdap relationships':      'gdap relationships partners',
     'gdap':                    'tenant governance administrator',
     'granular delegated admin':'tenant governance administrator',
     'csp admin':               'tenant governance administrator',

--- a/pipeline/synonyms.py
+++ b/pipeline/synonyms.py
@@ -27,8 +27,9 @@ SYNONYMS: dict[str, str] = {
     'passwordless':                 'passwordless authentication',
     'sspr':                         'self service password reset',
     'self-service password':        'self service password reset',
-    'password reset':               'self service password reset',
-    'reset user password':          'reset user account password',
+    'password reset':               'reset user password',
+    'reset password':              'reset non admin password',
+    'reset user password':          'reset non admin password',
     'tap':                          'temporary access pass',
     'temporary access pass':        'temporary access pass',
     'windows hello':                'passwordless authentication',
@@ -114,7 +115,7 @@ SYNONYMS: dict[str, str] = {
     'scoped admin':                 'administrative unit',
     'au':                           'administrative unit',
     'bulk user':                    'bulk create import users',
-    'manage groups':                'manage security groups',
+    'manage groups':                'group membership management',
     'dynamic group':                'dynamic membership group',
     'dynamic membership':           'dynamic membership group',
     'license':                      'license assignment',
@@ -227,6 +228,7 @@ SYNONYMS: dict[str, str] = {
     'recover deleted groups':       'entra backup administrator',
 
     # GDAP and tenant governance
+    'gdap relationships':           'gdap relationships partners',
     'gdap':                         'tenant governance administrator',
     'granular delegated admin':     'tenant governance administrator',
     'csp admin':                    'tenant governance administrator',

--- a/pipeline/test_pills.py
+++ b/pipeline/test_pills.py
@@ -52,10 +52,11 @@ EXPECTATIONS: list[tuple[str, str]] = [
 # Remove entries from this set as they are fixed by Week 2 ranking work
 # (BM25 scoring + synonym dict audit + over-reach cleanup).
 KNOWN_FAILURES: set[str] = {
-    "reset password",          # SSPR config hijack via 'password reset' synonym
-    "reset user password",     # External ID User Flow Admin keyword tie
-    "manage groups",           # Identity Governance ranks above Groups Admin
-    "GDAP relationships",      # Synonym chain produces noisy phrase, Reader wins
+    # All resolved in chunk/path-x-synonym-surgery:
+    # "reset password"       RESOLVED — explicit key -> 'reset non admin password'
+    # "reset user password"  RESOLVED — key -> 'reset non admin password'
+    # "manage groups"        RESOLVED — key -> 'group membership management'
+    # "GDAP relationships"   RESOLVED — plural key -> 'gdap relationships partners'
     # "restore deleted users" RESOLVED 2026-04-25 by Chunk 4 stopword guard
 }
 

--- a/pipeline/test_synonym_regression.py
+++ b/pipeline/test_synonym_regression.py
@@ -1,0 +1,106 @@
+"""
+test_synonym_regression.py
+
+Detects synonym expansions that make pill queries WORSE than no expansion.
+
+For each pill in PILLS, runs two queries against the worker:
+  1. Raw query (no synonym expansion)
+  2. Expanded query (after pipeline.synonyms.expand_query)
+
+Reports any pill where:
+  - Expanded result != expected role, AND
+  - Raw result == expected role
+
+Such a case means expansion is actively hurting that pill.
+
+Informational only — exit 0 always. The output is a signal for human
+review, not a CI gate. Synonyms have legitimate trade-offs across queries.
+"""
+
+import sys
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent))
+from synonyms import expand_query
+from test_pills import EXPECTATIONS
+
+WORKER_URL = "https://rolelens-worker.russo-antonio76.workers.dev"
+
+
+def fetch_top_role(query: str) -> str | None:
+    try:
+        resp = requests.get(
+            f"{WORKER_URL}/api/search",
+            params={"q": query},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        results = resp.json()
+        return results[0].get("min_role") if results else None
+    except Exception as exc:
+        print(f"  ERROR fetching {query!r}: {exc}", file=sys.stderr)
+        return None
+
+
+def main() -> int:
+    print(f"Synonym expansion regression check — {len(EXPECTATIONS)} pills")
+    print(f"Endpoint: {WORKER_URL}")
+    print("=" * 90)
+
+    expansion_helps   = []
+    expansion_hurts   = []
+    expansion_neutral = []
+    both_wrong        = []
+
+    for query, expected in EXPECTATIONS:
+        raw_role = fetch_top_role(query)
+        expanded = expand_query(query)
+        exp_role = fetch_top_role(expanded) if expanded != query else raw_role
+
+        raw_ok = raw_role == expected
+        exp_ok = exp_role == expected
+
+        if exp_ok and not raw_ok:
+            expansion_helps.append((query, expected, raw_role))
+        elif raw_ok and not exp_ok:
+            expansion_hurts.append((query, expected, exp_role, expanded))
+        elif raw_ok and exp_ok:
+            expansion_neutral.append(query)
+        else:
+            both_wrong.append((query, expected, raw_role, exp_role))
+
+    print(f"Expansion HELPS:   {len(expansion_helps)}")
+    print(f"Expansion HURTS:   {len(expansion_hurts)}")
+    print(f"Expansion NEUTRAL: {len(expansion_neutral)} (both correct)")
+    print(f"Both WRONG:        {len(both_wrong)} (search engine issue, not synonym)")
+    print()
+
+    if expansion_hurts:
+        print("WARNING — expansion makes these pills WORSE (review synonym entries):")
+        for q, expected, got, expanded in expansion_hurts:
+            print(f"  {q!r}")
+            print(f"    expected:    {expected}")
+            print(f"    raw result:  correct")
+            print(f"    expanded to: {expanded!r}")
+            print(f"    exp result:  {got}")
+            print()
+
+    if expansion_helps:
+        print("OK — expansion correctly helps these pills:")
+        for q, expected, got_raw in expansion_helps:
+            print(f"  {q!r}  (raw -> {got_raw!r}, expanded -> correct)")
+        print()
+
+    if both_wrong:
+        print("INFO — both raw AND expanded queries fail (search/corpus issue, not synonym):")
+        for q, expected, raw, exp in both_wrong:
+            print(f"  {q!r}  expected={expected!r}  raw->{raw!r}  expanded->{exp!r}")
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Resolves the 4 long-standing pill failures via narrow synonym dict edits, plus adds CI automation that prevents this class of bug recurring.

## Root causes (all different mechanisms)

| Pill | Was routing to | Root cause | Fix |
|------|---------------|------------|-----|
| `reset password` | Authentication Policy Admin | Step 3 reverse-synonym: `'password'` word mapped to `'self service password reset'` via `'sspr'` entry (appears first in dict, wins the slot) | Add explicit `'reset password'` Step 1 key → `'reset non admin password'` |
| `reset user password` | External ID User Flow Admin | `'reset user account password'` expansion — `'account'` keyword weighted toward User Flow tasks | Change to `'reset non admin password'` |
| `manage groups` | Identity Governance Admin | `'manage security groups'` expansion matched Identity Governance review tasks | Change to `'group membership management'` |
| `GDAP relationships` | Tenant Governance Reader | Step 2 hit on generic `'gdap'` key (existing entry) — only 1 task in corpus for Relationship Admin, Reader ranked above | Add `'gdap relationships'` (plural) before `'gdap'` → `'gdap relationships partners'` which uniquely targets the single corpus task |

## Files changed

- **`pipeline/synonyms.py`** + **`frontend/index.html`** — kept in sync (4 edits + 1 new key each)
- **`pipeline/test_pills.py`** — `KNOWN_FAILURES` set emptied (all 4 resolved, documented as comments)
- **`pipeline/test_synonym_regression.py`** — new script: runs every pill raw + expanded, flags any expansion that produces a worse result than no expansion; exit 0 always (informational)
- **`.github/workflows/refresh.yml`** — new informational step: synonym expansion regression check runs nightly after pill tests

## Verification

- Pill tests: **15 PASS, 0 KNOWN-FAIL, 0 REGRESSION** (was 11/4/0)
- Synonym regression check: **0 HURTS, 15 NEUTRAL** at baseline
- Frontend HTML: mojibake=0, SYNONYMS dict intact
- All Python files compile clean, YAML valid