### PR TITLE
fix(whatsnew): colored action text matches change-type

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -693,6 +693,9 @@
     .wn-glyph.modified { color: var(--warn); }
     .wn-name   { font-family: var(--font-mono); font-size: 13px; color: var(--text); flex: 1; }
     .wn-action { font-family: var(--font-body); font-size: 12px; color: var(--muted); }
+    .whats-new-entry.type-added .wn-action    { color: var(--accent); opacity: 0.85; }
+    .whats-new-entry.type-modified .wn-action { color: var(--warn);   opacity: 0.85; }
+    .whats-new-entry.type-removed .wn-action  { color: var(--danger); opacity: 0.85; }
     .wn-date   { font-family: var(--font-mono); font-size: 11px; color: var(--muted); white-space: nowrap; }
 
     .wn-show-all { display: flex; justify-content: center; padding: 10px 0 4px; }
@@ -2147,7 +2150,7 @@
       const gcls   = _WN_GLYPH_CLASS[type] ?? '';
       const action = type === 'MODIFIED' ? 'permissions updated' : (c.change_type?.toLowerCase() ?? '');
       const fresh  = c.date >= cutoff24h ? ' wn-fresh' : '';
-      return `<div class="whats-new-entry${fresh}" data-idx="${startIdx + i}">` +
+      return `<div class="whats-new-entry type-${gcls}${fresh}" data-idx="${startIdx + i}">` +
         `<span class="wn-fresh-dot"></span>` +
         `<span class="wn-glyph ${gcls}">${glyph}</span>` +
         `<span class="wn-name">${esc(c.role_name ?? '')}</span>` +


### PR DESCRIPTION
## Summary
- Each What's New entry div now carries a \`type-added\` / \`type-modified\` / \`type-removed\` parent class
- Three new CSS rules color \`.wn-action\` text to match the glyph: mint / amber / red at opacity 0.85
- Color signal scales from 13px glyph to full label width — panel is now scannable without reading each line

## Problem
Glyphs (✦ ◆ ⊘) were color-differentiated but action text ("added" / "permissions updated" / "removed") was uniformly gray. Three rows of identical gray verbs forced users to read rather than scan.

## Fix
1 line JS: entry div emits \`type-\${gcls}\` class alongside existing classes
3 lines CSS: \`.type-added .wn-action\` → mint, \`.type-modified .wn-action\` → amber, \`.type-removed .wn-action\` → red (opacity 0.85 to soften saturation)

## Verified
- All 6 gates passed: UTF-8 clean, 7/7 logic checks, critical structures intact, pills 15/0/0, synonym regression 0 HURTS
- Diff: 1 JS line modified, 3 CSS lines added — nothing else touched
- Pure frontend. Worker, D1, pipeline untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)