### PR TITLE
feat: Phase 3 — rich result card (permissions, alts, snippet, expand)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -313,16 +313,18 @@
       background: var(--surface);
       border: 1px solid var(--border);
       border-radius: var(--radius-lg);
-      padding: 28px 32px;
+      padding: 24px 28px;
       transition: border-color 0.15s;
+      container-type: inline-size;
     }
     .result-card:hover { border-color: #2D3F60; }
+    .result-card--top  { border-top: 2px solid rgba(0,229,163,0.35); }
 
     .card-top {
       display: flex;
       align-items: center;
       gap: 8px;
-      margin-bottom: 8px;
+      margin-bottom: 6px;
       flex-wrap: wrap;
     }
 
@@ -342,47 +344,192 @@
     .badge-privileged {
       font-family: var(--font-mono);
       font-size: 11px;
-      font-weight: 500;
-      letter-spacing: 0.06em;
+      font-weight: 700;
+      letter-spacing: 0.08em;
       text-transform: uppercase;
-      color: var(--warn);
-      background: rgba(251,191,36,0.08);
-      border: 1px solid rgba(251,191,36,0.25);
+      color: var(--danger);
+      background: rgba(248,113,113,0.10);
+      border: 1px solid rgba(248,113,113,0.35);
       padding: 3px 10px;
       border-radius: 4px;
     }
 
+    .badge-best-match {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      font-weight: 500;
+      color: var(--accent);
+      background: rgba(0,229,163,0.10);
+      border: 1px solid rgba(0,229,163,0.35);
+      padding: 2px 8px;
+      border-radius: 4px;
+    }
+
     .card-task {
+      font-size: 13px;
+      color: var(--muted);
+      margin-bottom: 4px;
+      line-height: 1.4;
+    }
+
+    .card-role-name {
+      font-family: var(--font-mono);
       font-size: 18px;
       font-weight: 500;
       color: var(--text);
+      margin-bottom: 8px;
+      line-height: 1.3;
+    }
+
+    .card-description {
+      font-size: 14px;
+      color: var(--muted);
+      margin-bottom: 12px;
+      line-height: 1.5;
+    }
+
+    .card-reasoning {
+      display: inline-block;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--accent);
+      opacity: 0.85;
+      background: rgba(0,229,163,0.06);
+      border: 1px solid rgba(0,229,163,0.18);
+      padding: 3px 12px;
+      border-radius: 20px;
       margin-bottom: 16px;
       line-height: 1.5;
     }
 
-    .card-bottom {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      flex-wrap: wrap;
-    }
+    .card-section { margin-bottom: 16px; }
 
-    .role-pill {
+    .card-section-label {
       font-family: var(--font-mono);
-      font-size: 14px;
+      font-size: 10px;
       font-weight: 500;
-      background: var(--accent);
-      color: #07080D;
-      padding: 6px 16px;
-      border-radius: 20px;
-      white-space: nowrap;
+      letter-spacing: 0.10em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 8px;
     }
 
-    .alt-roles {
+    .card-perms-list {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .card-perm-item {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: #94A3B8;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 4px 10px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .perm-path-ns     { color: var(--muted); }
+    .perm-path-action { color: var(--accent); opacity: 0.75; }
+
+    .card-perm-viewall {
+      display: inline-block;
+      margin-top: 6px;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--muted);
+      text-decoration: none;
+    }
+    .card-perm-viewall:hover { color: var(--accent); }
+
+    .card-alts-list {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .card-alt-item {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      padding: 8px 12px;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+    }
+    .alt-name {
       font-family: var(--font-mono);
       font-size: 13px;
+      font-weight: 500;
+      color: var(--text);
+    }
+    .alt-desc {
+      font-size: 12px;
+      color: var(--muted);
+      line-height: 1.4;
+    }
+
+    .card-snippet {
+      margin-bottom: 16px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .card-snippet-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      background: var(--surface2);
+      border-bottom: 1px solid var(--border);
+      padding: 6px 12px;
+    }
+    .card-snippet-label {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: 0.10em;
+      text-transform: uppercase;
       color: var(--muted);
     }
+    .card-snippet-code {
+      background: #0A0C12;
+      padding: 12px 16px;
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: #94A3B8;
+      line-height: 1.7;
+      white-space: pre;
+      margin: 0;
+    }
+    .snip-comment { color: var(--muted); font-style: italic; opacity: 0.65; }
+
+    .copy-btn {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--muted);
+      background: transparent;
+      border: 1px solid var(--border);
+      padding: 3px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .copy-btn:hover { color: var(--accent); border-color: rgba(0,229,163,0.4); }
+
+    .card-footer {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-top: 4px;
+    }
+    .card-footer-badges { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
 
     .source-link {
       margin-left: auto;
@@ -392,6 +539,49 @@
       white-space: nowrap;
     }
     .source-link:hover { color: var(--accent); }
+
+    .card-expand-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin: 8px 0 4px;
+    }
+    .card-meta {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--muted);
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .card-expand-btn {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--accent);
+      background: transparent;
+      border: 1px solid rgba(0,229,163,0.30);
+      padding: 4px 10px;
+      border-radius: 4px;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: background 0.15s;
+    }
+    .card-expand-btn:hover { background: rgba(0,229,163,0.08); }
+
+    .card-details[hidden] { display: none; }
+    .card-details { margin-top: 12px; }
+
+    @container (max-width: 480px) {
+      .card-role-name    { font-size: 15px; }
+      .card-snippet-code { font-size: 11px; }
+      .card-perm-item    { font-size: 11px; }
+    }
 
     /* ── Role Diff mode ─────────────────────────────────────────────── */
     .diff-inputs {
@@ -1867,34 +2057,162 @@
 
   const NEW_BADGE = `<span style="background:#00E5A3;color:#07080D;font-family:'IBM Plex Mono',monospace;font-size:10px;padding:2px 6px;border-radius:4px;margin-left:6px;vertical-align:middle">NEW</span>`;
 
-  function renderResultCard(r, idx, results) {
-    const altText = (r.alt_roles && r.alt_roles.length > 0)
-      ? `<span class="alt-roles">Also: ${r.alt_roles.join(', ')}</span>`
-      : '';
-    const privBadge = r.is_privileged
-      ? `<span class="badge-privileged">⚠ Privileged</span>`
-      : '';
-    const newBadge = isNewRole(r.role_id) ? NEW_BADGE : '';
-    // 'Best match' fires when top score is decisively higher than runner-up.
-    // 1.5x threshold prevents false confidence on close calls. Single-result queries always tag.
-    const isBestMatch = idx === 0
-      && (results.length === 1 || (results[0].score || 0) >= (results[1].score || 0) * 1.5);
-    const bestBadge = isBestMatch
-      ? `<span style="background:rgba(0,229,163,0.12);border:1px solid #00E5A3;color:#00E5A3;font-family:'IBM Plex Mono',monospace;font-size:10px;padding:2px 6px;border-radius:4px;margin-left:6px;vertical-align:middle">Best match</span>`
+  function renderCardPermissions(r) {
+    if (!r.relevant_permissions || r.relevant_permissions.length === 0) return '';
+    const MAX_SHOWN = 3;
+    const shown = r.relevant_permissions.slice(0, MAX_SHOWN);
+    const remainder = r.relevant_permissions.length - MAX_SHOWN;
+    const items = shown.map(p => {
+      const lastSlash = p.lastIndexOf('/');
+      const ns     = lastSlash >= 0 ? esc(p.slice(0, lastSlash + 1)) : '';
+      const action = lastSlash >= 0 ? esc(p.slice(lastSlash + 1))    : esc(p);
+      return `<div class="card-perm-item"><span class="perm-path-ns">${ns}</span><span class="perm-path-action">${action}</span></div>`;
+    }).join('');
+    const moreLink = remainder > 0
+      ? `<a href="${esc(r.source_url)}" target="_blank" rel="noopener" class="card-perm-viewall">View all ${r.relevant_permissions.length} permissions →</a>`
       : '';
     return `
-      <div class="result-card">
-        <div class="card-top">
-          <span class="badge-area">${esc(r.feature_area)}</span>
-          ${privBadge}
-        </div>
-        <div class="card-task">${esc(r.task)}</div>
-        <div class="card-bottom">
-          <span class="role-pill">${esc(r.min_role)}</span>${newBadge}${bestBadge}
-          ${altText}
-          <a href="${esc(r.source_url)}" target="_blank" rel="noopener" class="source-link">Microsoft Learn ↗</a>
-        </div>
+      <div class="card-section">
+        <div class="card-section-label">Top permissions</div>
+        <div class="card-perms-list">${items}</div>
+        ${moreLink}
       </div>`;
+  }
+
+  function renderCardAlternatives(r) {
+    if (!r.alt_roles_enriched || r.alt_roles_enriched.length === 0) return '';
+    const items = r.alt_roles_enriched.map(a => `
+      <div class="card-alt-item">
+        <span class="alt-name">${esc(a.name)}</span>
+        ${a.description ? `<span class="alt-desc">${esc(a.description)}</span>` : ''}
+      </div>`).join('');
+    return `
+      <div class="card-section">
+        <div class="card-section-label">Alternative roles</div>
+        <div class="card-alts-list">${items}</div>
+      </div>`;
+  }
+
+  function renderCardSnippet(r, idx) {
+    const snippetId = `snip-${idx}`;
+    const btnId     = `copy-btn-${idx}`;
+    const roleName  = esc(r.min_role);
+    const task      = esc(r.task);
+    return `
+      <div class="card-snippet">
+        <div class="card-snippet-header">
+          <span class="card-snippet-label">PowerShell — Graph module</span>
+          <button class="copy-btn" id="${btnId}" onclick="copySnippet('${snippetId}','${btnId}')">Copy</button>
+        </div>
+        <pre class="card-snippet-code" id="${snippetId}"><span class="snip-comment"># Assign ${roleName} — minimum privilege for: ${task}</span>
+
+$role = Get-MgRoleManagementDirectoryRoleDefinition \`
+  -Filter "displayName eq '${roleName}'"
+
+$params = @{
+  RoleDefinitionId = $role.Id
+  PrincipalId      = "&lt;PRINCIPAL_OBJECT_ID&gt;"
+  DirectoryScopeId = "/"
+}
+New-MgRoleManagementDirectoryRoleAssignment @params</pre>
+      </div>`;
+  }
+
+  function toggleCardDetails(idx) {
+    const details = document.getElementById(`card-details-${idx}`);
+    const btn     = document.getElementById(`card-expand-${idx}`);
+    if (!details || !btn) return;
+    const expanded = !details.hidden;
+    const apply = () => {
+      details.hidden = expanded;
+      btn.textContent = expanded ? 'Show details ▾' : 'Hide details ▴';
+    };
+    if (document.startViewTransition) { document.startViewTransition(apply); } else { apply(); }
+  }
+
+  function copySnippet(snippetId, btnId) {
+    const pre = document.getElementById(snippetId);
+    if (!pre) return;
+    const text = pre.textContent;
+    const btn  = document.getElementById(btnId);
+    navigator.clipboard.writeText(text).then(() => {
+      if (btn) { btn.textContent = 'Copied!'; setTimeout(() => { btn.textContent = 'Copy'; }, 2000); }
+    }).catch(() => {
+      const range = document.createRange();
+      range.selectNodeContents(pre);
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+  }
+
+  function renderResultCard(r, idx, results) {
+    const isBestMatch = idx === 0
+      && (results.length === 1 || (results[0].score || 0) >= (results[1].score || 0) * 1.5);
+    const privBadge = r.is_privileged
+      ? `<span class="badge-privileged">⚠ PRIVILEGED</span>`
+      : '';
+    const newBadge  = isNewRole(r.role_id) ? NEW_BADGE : '';
+    const bestBadge = isBestMatch ? `<span class="badge-best-match">Best match</span>` : '';
+
+    const descHtml = r.min_role_description
+      ? `<div class="card-description">${esc(r.min_role_description)}</div>`
+      : '';
+    const reasoningHtml = r.match_reasoning
+      ? `<div class="card-reasoning">${esc(r.match_reasoning)}</div>`
+      : '';
+    const permsHtml    = renderCardPermissions(r);
+    const altsHtml     = renderCardAlternatives(r);
+    const snippetHtml  = renderCardSnippet(r, idx);
+    const cardClass    = idx === 0 ? 'result-card result-card--top' : 'result-card';
+
+    if (idx === 0) {
+      return `
+        <div class="${cardClass}">
+          <div class="card-top">
+            <span class="badge-area">${esc(r.feature_area)}</span>
+            ${privBadge}
+          </div>
+          <div class="card-task">${esc(r.task)}</div>
+          <div class="card-role-name">${esc(r.min_role)}</div>
+          ${descHtml}
+          ${reasoningHtml}
+          ${permsHtml}
+          ${altsHtml}
+          ${snippetHtml}
+          <div class="card-footer">
+            <div class="card-footer-badges">${newBadge}${bestBadge}</div>
+            <a href="${esc(r.source_url)}" target="_blank" rel="noopener" class="source-link">Microsoft Learn ↗</a>
+          </div>
+        </div>`;
+    } else {
+      const scoreText  = r.score != null ? `Score: ${r.score}` : '';
+      const reasonMeta = r.match_reasoning ? ` · ${r.match_reasoning}` : '';
+      return `
+        <div class="${cardClass}">
+          <div class="card-top">
+            <span class="badge-area">${esc(r.feature_area)}</span>
+            ${privBadge}
+          </div>
+          <div class="card-task">${esc(r.task)}</div>
+          <div class="card-role-name">${esc(r.min_role)}</div>
+          ${descHtml}
+          <div class="card-expand-row">
+            <span class="card-meta">${esc(scoreText + reasonMeta)}</span>
+            <button class="card-expand-btn" id="card-expand-${idx}" onclick="toggleCardDetails(${idx})">Show details ▾</button>
+          </div>
+          <div class="card-details" id="card-details-${idx}" hidden>
+            ${reasoningHtml}
+            ${permsHtml}
+            ${altsHtml}
+            ${snippetHtml}
+          </div>
+          <div class="card-footer">
+            <div class="card-footer-badges">${newBadge}</div>
+            <a href="${esc(r.source_url)}" target="_blank" rel="noopener" class="source-link">Microsoft Learn ↗</a>
+          </div>
+        </div>`;
+    }
   }
 
   function renderResults(results) {


### PR DESCRIPTION
## Summary
- **Top card** fully expanded by default: role name as 18px mono heading, role description, match-reasoning pill, top-3 permissions with namespace/action colorization, enriched alternative role cards with descriptions, PowerShell Graph-module snippet with one-click copy
- **Non-top cards** collapsed by default — task + role name + description visible, Score+reasoning meta line, "Show details ▾" toggle (View Transitions API) that reveals reasoning, permissions, alts, and snippet
- **Badge improvements**: Privileged badge promoted to danger red (`--danger`); Best match extracted to `.badge-best-match` CSS class (was inline style)
- **Container query** at 480px for smaller font sizes; `prefers-reduced-motion` inherited from existing animations

## What's new from the worker (Phase 2, already merged)
Phase 3 consumes `min_role_description`, `match_reasoning`, `relevant_permissions`, and `alt_roles_enriched` — all added in Phase 2 (#54).

## Verification
- UTF-8 clean, 21 structural checks pass
- Pill regression 15/0/0 · Synonym regression 0 HURTS

## Test plan
- [ ] Search "reset password" → top card shows Password Administrator as heading, description, reasoning pill, permissions, snippet
- [ ] Search "manage groups" → top card shows permissions starting with `microsoft.directory/groups/`
- [ ] Second result "Show details ▾" expands; "Hide details ▴" collapses
- [ ] Click Copy on snippet → clipboard contains clean PowerShell (no HTML entities)
- [ ] Privileged role (e.g. "assign roles") shows red ⚠ PRIVILEGED badge
- [ ] "Best match" badge appears on decisive top result; absent on close calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)