### PR TITLE
fix(ci): prevent merge conflicts on auto-committed generated files

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -134,7 +134,19 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/ assets/quality-dashboard.svg README.md .sentrux/baseline.json
-          git diff --staged --quiet || git commit -m "data: nightly refresh [skip ci]"
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "data: nightly refresh [skip ci]"
+          # Rebase onto latest master; -X ours keeps pipeline-generated data on conflict
+          git fetch origin master
+          git rebase -X ours origin/master || {
+            git rebase --abort
+            echo "Rebase failed — force-pushing since pipeline data is authoritative"
+            git push --force-with-lease origin master
+            exit 0
+          }
           git push origin master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -122,17 +122,23 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: 0
 
-      - name: Generate security dashboard SVG
-        run: python pipeline/trivy_dashboard_svg.py
-
-      - name: Commit dashboard SVG
+      - name: Generate and commit security dashboard SVG
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Fetch latest master to avoid merge conflicts on generated files
+          git fetch origin master
+          git reset --hard origin/master
+          # Regenerate dashboard from latest code
+          python pipeline/trivy_dashboard_svg.py
+          # Commit and push
           git add assets/security-dashboard.svg
-          git diff --staged --quiet || git commit -m "data: update security dashboard [skip ci]"
-          git pull --rebase origin master
-          git push origin master
+          if git diff --staged --quiet; then
+            echo "No dashboard changes to commit."
+          else
+            git commit -m "data: update security dashboard [skip ci]"
+            git push origin master
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

The **Trivy Security Scan** workflow fails sporadically when the 'Commit dashboard SVG' step hits a merge conflict during `git pull --rebase origin master`. This happened in [run #72](https://github.com/arusso-aboutcloud/Entra-Rolelens/actions/runs/25753561785) when master advanced between checkout and push (another workflow or commit landed first).

The same race condition exists in the nightly `refresh.yml` — a bare `git push` can fail if master moved during the long pipeline run.

## Fix

### `trivy.yml`
- Combined the 'Generate' + 'Commit' steps into a single step
- Fetches latest `origin/master` and resets before generating the dashboard SVG
- No rebase needed — we always generate from the latest code, then push cleanly

### `refresh.yml`  
- Added `git fetch + rebase -X ours` before push to integrate any concurrent commits
- `-X ours` ensures pipeline-generated data wins on conflict (pipeline is authoritative)
- Falls back to `--force-with-lease` if rebase fails structurally (extremely rare for data files)

## Testing

The Trivy workflow `dashboard` job only runs on push to master and schedule (skips PRs). After merge, the next push to master will validate the fix.