### PR TITLE
security: pin Python deps to patched versions + least-privilege workflow tokens

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -5,6 +5,11 @@ on:
     - cron: '0 1 * * *'
   workflow_dispatch:
 
+# Least privilege: read-only by default; the refresh job below requests the
+# write + OIDC scopes it actually needs.
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -9,15 +9,19 @@ on:
     - cron: "0 6 * * 0" # Weekly Sunday 06:00 UTC
   workflow_dispatch: # Manual trigger
 
+# Least privilege: read-only by default. Write scopes are granted per-job below
+# only where needed (SARIF upload -> security-events; dashboard commit -> contents).
 permissions:
   contents: read
-  security-events: write # For SARIF upload
 
 jobs:
   # ── Dependency vulnerability scan (filesystem) ──
   vuln-scan:
     name: Vuln Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # SARIF upload
     strategy:
       fail-fast: false
       matrix:
@@ -52,6 +56,9 @@ jobs:
   config-scan:
     name: Config Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # SARIF upload
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -12,9 +12,10 @@ on:
         required: false
         default: ''
 
+# Least privilege: read-only by default; the single job below requests the
+# write/model scopes it actually needs (git push + GitHub Models inference).
 permissions:
-  contents: write
-  models: read          # GitHub Copilot / GitHub Models — no extra secret needed
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -22,6 +23,9 @@ env:
 jobs:
   update-readme:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # git push README update
+      models: read          # GitHub Models inference — no extra secret needed
 
     steps:
       - name: Harden Runner

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,5 +1,8 @@
-requests
-beautifulsoup4
-lxml
-azure-identity
-requests
+# Pinned to current, patched versions (verified to install and import against the
+# pipeline code, and to support the CI Python 3.11 runtime). Pinning clears the
+# OSV "Vulnerabilities" finding (historical lxml/requests CVEs surfaced because the
+# packages were unpinned) and makes builds reproducible.
+requests==2.32.5
+beautifulsoup4==4.13.4
+lxml==6.1.1
+azure-identity==1.25.1


### PR DESCRIPTION
Resolves the **actionable** code-scanning findings on the repo. Of the 72 alerts, **71 are OpenSSF Scorecard posture checks** (not code bugs) and **1 is CodeQL** (`js/xss-through-dom`, already **fixed**). This PR fixes the two findings that represent real risk, with **no application behavior change**.

## 1. Dependency vulnerabilities — 14 OSV CVEs (Scorecard `VulnerabilitiesID`)
`pipeline/requirements.txt` was **completely unpinned**, so the scanner flagged the entire historical CVE list for `lxml`/`requests` (PYSEC-2014 … 2022, requests proxy-auth/cert advisories). 

**Fix:** pin to current patched versions + remove a duplicate `requests`:
```
requests==2.32.5
beautifulsoup4==4.13.4
lxml==6.1.1
azure-identity==1.25.1
```

### Verified safe (clean venv)
- ✅ Installs cleanly from the new `requirements.txt`
- ✅ All **14 pipeline modules byte-compile and import**
- ✅ The exact `BeautifulSoup(html, "lxml")` parse the code performs returns correct results
- ✅ Code only uses **stable APIs** (requests HTTP, bs4 lxml-parser backend, `DefaultAzureCredential`) — version bumps are behavior-neutral
- ✅ CI runtime (**Python 3.11**) is supported by all pinned versions

## 2. Token permissions (Scorecard `TokenPermissionsID`)
Make `GITHUB_TOKEN` least-privilege: **top-level read-only by default**, write scopes moved to the specific jobs that need them — **no required scope lost**:

| Workflow | Change | Preserved scope |
|---|---|---|
| `trivy.yml` | `security-events: write` moved from top-level → the 2 SARIF-uploading jobs (`vuln-scan`, `config-scan`) | dashboard keeps `contents: write`; sbom only needs read (artifact upload) |
| `update-readme.yml` | `contents: write` + `models: read` moved to the `update-readme` job | git push + GitHub Models inference intact |
| `refresh.yml` | added read-only top-level default | job keeps `contents`/`issues`/`id-token: write` (git push + Entra OIDC) |

All 5 workflow files validated as **parseable YAML**; required per-job scopes confirmed present post-change.

## Not included (separate PR, if desired)
Pure supply-chain hardening with no exploitable risk:
- Pinning GitHub Actions to commit SHAs (`PinnedDependenciesID` ×33)
- Project-maturity signals (Fuzzing / CodeReview / CIIBestPractices)

The single CodeQL code vuln (`js/xss-through-dom`) is already **fixed** — nothing to do there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)