### PR TITLE
security: bump requests to 2.33.0 (CVE-2026-25645)

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -2,7 +2,7 @@
 # pipeline code, and to support the CI Python 3.11 runtime). Pinning clears the
 # OSV "Vulnerabilities" finding (historical lxml/requests CVEs surfaced because the
 # packages were unpinned) and makes builds reproducible.
-requests==2.32.5
+requests==2.33.0
 beautifulsoup4==4.13.4
 lxml==6.1.1
 azure-identity==1.25.1


### PR DESCRIPTION
Follow-up to #66. Trivy/Scorecard flagged the **last remaining** dependency vuln after pinning:

- **CVE-2026-25645 = GHSA-gc5v-m9x4-r6x2** — Requests insecure temp-file reuse in `extract_zipped_paths()`, vulnerable `< 2.33.0`, fixed in **2.33.0**.

Bumps `requests==2.32.5 -> 2.33.0`. Patch-level, API-stable (code uses basic `requests` HTTP only).

**Verified:** clean-venv install from `requirements.txt`, all pipeline modules import, and the `BeautifulSoup(html,"lxml")` parse passes. This clears both the Trivy CVE alert and the Scorecard `VulnerabilitiesID` (OSV count was already 14 → 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)