### PR TITLE
security: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -23,25 +23,25 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Azure Login
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           allow-no-subscriptions: true # Essential since you are only accessing Graph API
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,23 +19,23 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
           publish_results: true # Publish to OpenSSF REST API
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: scorecard-results.sarif
           category: scorecard

--- a/.github/workflows/sentrux.yml
+++ b/.github/workflows/sentrux.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,14 +30,14 @@ jobs:
           - pipeline  # Python (requirements.txt)
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Trivy fs scan (${{ matrix.path }})
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: ${{ matrix.path }}
@@ -47,7 +47,7 @@ jobs:
           exit-code: 0 # Report but don't fail
 
       - name: Upload vuln SARIF (${{ matrix.path }})
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy-vuln-${{ matrix.path }}.sarif
           category: trivy-vuln-${{ matrix.path }}
@@ -61,14 +61,14 @@ jobs:
       security-events: write # SARIF upload
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Trivy config scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
           scan-ref: .
@@ -80,7 +80,7 @@ jobs:
           # wrangler.toml is also checked for misconfigurations
 
       - name: Upload config SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy-config.sarif
           category: trivy-config
@@ -95,16 +95,16 @@ jobs:
       contents: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
@@ -112,7 +112,7 @@ jobs:
         run: mkdir -p .trivy
 
       - name: Scan worker deps (JSON)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: worker
@@ -122,7 +122,7 @@ jobs:
           exit-code: 0
 
       - name: Scan pipeline deps (JSON)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: pipeline
@@ -159,14 +159,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Generate SBOM (worker)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: worker
@@ -174,7 +174,7 @@ jobs:
           output: sbom-worker.json
 
       - name: Generate SBOM (pipeline)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: pipeline
@@ -182,7 +182,7 @@ jobs:
           output: sbom-pipeline.json
 
       - name: Upload SBOMs as artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sboms
           path: |

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -29,13 +29,13 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
       # ── 1. Checkout ────────────────────────────────────────────────────────
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -133,7 +133,7 @@ jobs:
       # ── 5. Call GitHub Copilot via actions/ai-inference ────────────────────
       - name: Generate README sections with GitHub Copilot
         id: ai
-        uses: actions/ai-inference@v2
+        uses: actions/ai-inference@a7805884c80886efc241e94a5351df715968a0ad # v2
         with:
           model: openai/gpt-4o-mini     # swap to: anthropic/claude-3-5-haiku — same token
           prompt-file: /tmp/prompt.txt


### PR DESCRIPTION
Final hardening PR — clears the **33× `PinnedDependenciesID`** Scorecard findings.

Pins all 9 distinct GitHub Actions to the **exact commit SHA of the version tag already in use**, each with a `# vX` comment so it stays readable and easy to bump.

**Behavior is identical** — the SHA is the commit each tag currently points to. This just prevents a moved or compromised tag from silently changing what runs in CI (the supply-chain risk Scorecard flags).

| Action | Tag | Pinned SHA |
|---|---|---|
| actions/ai-inference | v2 | `a7805884` |
| actions/checkout | v6 | `df4cb1c0` |
| actions/setup-python | v6 | `a309ff8b` |
| actions/upload-artifact | v7 | `043fb46d` |
| aquasecurity/trivy-action | v0.36.0 | `ed142fd0` |
| azure/login | v3 | `532459ea` |
| github/codeql-action/upload-sarif | v4 | `8aad20d1` |
| ossf/scorecard-action | v2.4.3 | `4eaacf05` |
| step-security/harden-runner | v2 | `ab7a9404` |

**Validated:** all 5 workflows parse as YAML; 32 refs pinned, every one keeping its version comment; pure ref swaps (32 insertions / 32 deletions, no structural change). CI on this PR exercises the pinned actions end-to-end.

After this merges, the only remaining open code-scanning items are the 4 informational project-maturity signals (Fuzzing / CodeReview / CIIBestPractices / Maintained) — not vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)