### PR TITLE
feat(whats-new): click-to-expand rows with red/green permission detail

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -21,7 +21,11 @@
     "role_id": "db506228-d27e-4b7d-95e5-295956d6615f",
     "role_name": "Agent ID Administrator",
     "field": "permissions",
-    "detail": "2 permissions added"
+    "detail": "2 permissions added",
+    "added_permissions": [
+      "microsoft.directory/agentUsers/photo/update",
+      "microsoft.directory/agentUsers/reprocessLicenseAssignment"
+    ]
   },
   {
     "date": "2026-04-30",
@@ -29,7 +33,9 @@
     "role_id": "adb2368d-a9be-41b5-8667-d96778e081b0",
     "role_name": "Agent ID Developer",
     "field": "description",
-    "detail": "description changed: \"Create an agent blueprint and its service principal in a tenant. User will be added as an owner of the agent blueprint and its service principal.\" -> \"Create an agent identity blueprint and its agent identity blueprint principal in a tenant. User will be added as an owner of the created agent identity blueprint and its agent identity blueprint principal.\""
+    "detail": "description changed: \"Create an agent blueprint and its service principal in a tenant. User will be added as an owner of the agent blueprint and its service principal.\" -> \"Create an agent identity blueprint and its agent identity blueprint principal in a tenant. User will be added as an owner of the created agent identity blueprint and its agent identity blueprint principal.\"",
+    "old": "Create an agent blueprint and its service principal in a tenant. User will be added as an owner of the agent blueprint and its service principal.",
+    "new": "Create an agent identity blueprint and its agent identity blueprint principal in a tenant. User will be added as an owner of the created agent identity blueprint and its agent identity blueprint principal."
   },
   {
     "date": "2026-04-30",
@@ -37,7 +43,9 @@
     "role_id": "e3973bdf-4987-49ae-837a-ba8e231c7286",
     "role_name": "Azure DevOps Administrator",
     "field": "description",
-    "detail": "description changed: \"Can manage Azure DevOps policies and settings.\" -> \"Manage Azure DevOps policies and settings.\""
+    "detail": "description changed: \"Can manage Azure DevOps policies and settings.\" -> \"Manage Azure DevOps policies and settings.\"",
+    "old": "Can manage Azure DevOps policies and settings.",
+    "new": "Manage Azure DevOps policies and settings."
   },
   {
     "date": "2026-04-30",
@@ -45,7 +53,9 @@
     "role_id": "892c5842-a9a6-463a-8041-72aa08ca3cf6",
     "role_name": "Cloud App Security Administrator",
     "field": "description",
-    "detail": "description changed: \"Can manage all aspects of the Defender for Cloud Apps product.\" -> \"Manage all aspects of the Defender for Cloud Apps product.\""
+    "detail": "description changed: \"Can manage all aspects of the Defender for Cloud Apps product.\" -> \"Manage all aspects of the Defender for Cloud Apps product.\"",
+    "old": "Can manage all aspects of the Defender for Cloud Apps product.",
+    "new": "Manage all aspects of the Defender for Cloud Apps product."
   },
   {
     "date": "2026-04-30",
@@ -53,7 +63,9 @@
     "role_id": "a9ea8996-122f-4c74-9520-8edcd192826c",
     "role_name": "Fabric Administrator",
     "field": "description",
-    "detail": "description changed: \"Can manage all aspects of the Fabric and Power BI products.\" -> \"Manage all aspects of the Fabric and Power BI products.\""
+    "detail": "description changed: \"Can manage all aspects of the Fabric and Power BI products.\" -> \"Manage all aspects of the Fabric and Power BI products.\"",
+    "old": "Can manage all aspects of the Fabric and Power BI products.",
+    "new": "Manage all aspects of the Fabric and Power BI products."
   },
   {
     "date": "2026-04-30",
@@ -61,7 +73,10 @@
     "role_id": "62e90394-69f5-4237-9190-012177145e10",
     "role_name": "Global Administrator",
     "field": "permissions",
-    "detail": "1 permission added"
+    "detail": "1 permission added",
+    "added_permissions": [
+      "microsoft.commerce.tenantRelationships/customerDelegatedAdminPrivileges/allProperties/allTasks"
+    ]
   },
   {
     "date": "2026-04-30",
@@ -69,7 +84,10 @@
     "role_id": "8ac3fc64-6eca-42ea-9e69-59f4c7b60eb2",
     "role_name": "Hybrid Identity Administrator",
     "field": "permissions",
-    "detail": "1 permission added"
+    "detail": "1 permission added",
+    "added_permissions": [
+      "microsoft.directory/applications/disablement/update"
+    ]
   },
   {
     "date": "2026-04-30",
@@ -77,7 +95,9 @@
     "role_id": "31e939ad-9672-4796-9c2e-873181342d2d",
     "role_name": "Insights Business Leader",
     "field": "description",
-    "detail": "description changed: \"Can view and share dashboards and insights via the Microsoft 365 Insights app.\" -> \"View and share dashboards and insights via the Microsoft Viva Insights app.\""
+    "detail": "description changed: \"Can view and share dashboards and insights via the Microsoft 365 Insights app.\" -> \"View and share dashboards and insights via the Microsoft Viva Insights app.\"",
+    "old": "Can view and share dashboards and insights via the Microsoft 365 Insights app.",
+    "new": "View and share dashboards and insights via the Microsoft Viva Insights app."
   },
   {
     "date": "2026-04-30",
@@ -85,7 +105,9 @@
     "role_id": "744ec460-397e-42ad-a462-8b3f9747a02c",
     "role_name": "Knowledge Manager",
     "field": "description",
-    "detail": "description changed: \"Can organize, create, manage, and promote topics and knowledge.\" -> \"Organize, create, manage, and promote topics and knowledge.\""
+    "detail": "description changed: \"Can organize, create, manage, and promote topics and knowledge.\" -> \"Organize, create, manage, and promote topics and knowledge.\"",
+    "old": "Can organize, create, manage, and promote topics and knowledge.",
+    "new": "Organize, create, manage, and promote topics and knowledge."
   },
   {
     "date": "2026-04-30",
@@ -93,7 +115,9 @@
     "role_id": "11648597-926c-4cf3-9c36-bcebb0ba8dcc",
     "role_name": "Power Platform Administrator",
     "field": "description",
-    "detail": "description changed: \"Can create and manage all aspects of Microsoft Dynamics 365, Power Apps and Power Automate.\" -> \"Manage all aspects of Microsoft Dynamics 365, Power Apps and Power Automate.\""
+    "detail": "description changed: \"Can create and manage all aspects of Microsoft Dynamics 365, Power Apps and Power Automate.\" -> \"Manage all aspects of Microsoft Dynamics 365, Power Apps and Power Automate.\"",
+    "old": "Can create and manage all aspects of Microsoft Dynamics 365, Power Apps and Power Automate.",
+    "new": "Manage all aspects of Microsoft Dynamics 365, Power Apps and Power Automate."
   },
   {
     "date": "2026-05-27",
@@ -101,7 +125,9 @@
     "role_id": "db506228-d27e-4b7d-95e5-295956d6615f",
     "role_name": "Agent ID Administrator",
     "field": "description",
-    "detail": "description changed: \"Manage all aspects of agents in a tenant including identity lifecycle operations for agent blueprints, agent service principals, agent identities, and agentic users.\" -> \"Manage all aspects of agents in a tenant including identity lifecycle operations for agent blueprints, agent identity blueprint principals, agent identities, and agentic users.\""
+    "detail": "description changed: \"Manage all aspects of agents in a tenant including identity lifecycle operations for agent blueprints, agent service principals, agent identities, and agentic users.\" -> \"Manage all aspects of agents in a tenant including identity lifecycle operations for agent blueprints, agent identity blueprint principals, agent identities, and agentic users.\"",
+    "old": "Manage all aspects of agents in a tenant including identity lifecycle operations for agent blueprints, agent service principals, agent identities, and agentic users.",
+    "new": "Manage all aspects of agents in a tenant including identity lifecycle operations for agent blueprints, agent identity blueprint principals, agent identities, and agentic users."
   },
   {
     "date": "2026-05-27",
@@ -109,7 +135,9 @@
     "role_id": "45d8d3c5-c802-45c6-b32a-1d70b5e1e86e",
     "role_name": "Identity Governance Administrator",
     "field": "isPrivileged",
-    "detail": "isPrivileged changed: false -> true"
+    "detail": "isPrivileged changed: false -> true",
+    "old": false,
+    "new": true
   },
   {
     "date": "2026-06-13",
@@ -117,7 +145,19 @@
     "role_id": "db506228-d27e-4b7d-95e5-295956d6615f",
     "role_name": "Agent ID Administrator",
     "field": "permissions",
-    "detail": "6 permissions added, 2 permissions removed"
+    "detail": "6 permissions added, 2 permissions removed",
+    "added_permissions": [
+      "microsoft.directory/agentIdentities/authentication/update",
+      "microsoft.directory/agentIdentityBlueprintPrincipals/authentication/update",
+      "microsoft.directory/deletedItems.agentIdentities/delete",
+      "microsoft.directory/deletedItems.agentIdentities/restore",
+      "microsoft.directory/deletedItems.agentIdentityBlueprintPrincipals/delete",
+      "microsoft.directory/deletedItems.agentIdentityBlueprintPrincipals/restore"
+    ],
+    "removed_permissions": [
+      "microsoft.directory/agentIdentityBlueprints/verification/update",
+      "microsoft.directory/groups.unified/createAsOwner"
+    ]
   },
   {
     "date": "2026-06-13",
@@ -125,7 +165,10 @@
     "role_id": "adb2368d-a9be-41b5-8667-d96778e081b0",
     "role_name": "Agent ID Developer",
     "field": "permissions",
-    "detail": "1 permission added"
+    "detail": "1 permission added",
+    "added_permissions": [
+      "microsoft.directory/agentIdentityBlueprints/createAsOwner"
+    ]
   },
   {
     "date": "2026-06-13",
@@ -133,7 +176,32 @@
     "role_id": "62e90394-69f5-4237-9190-012177145e10",
     "role_name": "Global Administrator",
     "field": "permissions",
-    "detail": "2 permissions added, 19 permissions removed"
+    "detail": "2 permissions added, 19 permissions removed",
+    "added_permissions": [
+      "microsoft.directory/agentIdentities/authentication/update",
+      "microsoft.directory/agentIdentityBlueprintPrincipals/authentication/update"
+    ],
+    "removed_permissions": [
+      "microsoft.directory/agentIdentityBlueprints/allProperties/read",
+      "microsoft.directory/agentIdentityBlueprints/verification/update",
+      "microsoft.directory/agentUsers/assignLicense",
+      "microsoft.directory/agentUsers/basic/update",
+      "microsoft.directory/agentUsers/create",
+      "microsoft.directory/agentUsers/delete",
+      "microsoft.directory/agentUsers/disable",
+      "microsoft.directory/agentUsers/enable",
+      "microsoft.directory/agentUsers/invalidateAllRefreshTokens",
+      "microsoft.directory/agentUsers/lifeCycleInfo/read",
+      "microsoft.directory/agentUsers/lifeCycleInfo/update",
+      "microsoft.directory/agentUsers/manager/update",
+      "microsoft.directory/agentUsers/photo/update",
+      "microsoft.directory/agentUsers/reprocessLicenseAssignment",
+      "microsoft.directory/agentUsers/restore",
+      "microsoft.directory/agentUsers/revokeSignInSessions",
+      "microsoft.directory/agentUsers/sponsors/update",
+      "microsoft.directory/agentUsers/usageLocation/update",
+      "microsoft.directory/agentUsers/userPrincipalName/update"
+    ]
   },
   {
     "date": "2026-06-17",
@@ -141,6 +209,9 @@
     "role_id": "1fe13547-53f6-408d-ac04-7f8eed167b38",
     "role_name": "AI Reader",
     "field": "permissions",
-    "detail": "1 permission removed"
+    "detail": "1 permission removed",
+    "removed_permissions": [
+      "microsoft.office365.usageReports/allEntities/allProperties/read"
+    ]
   }
 ]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -856,16 +856,21 @@
 
     /* Expandable rows: chevron affordance + click-to-open detail. */
     .wn-chev, .wn-chev-spacer {
-      width: 12px;
+      width: 16px;
       flex-shrink: 0;
-      color: var(--muted);
-      font-size: 11px;
       text-align: center;
-      transition: transform 0.18s ease;
+      transition: transform 0.18s ease, color 0.18s ease;
     }
-    .wn-item.wn-open .wn-chev { transform: rotate(90deg); }
+    .wn-chev {
+      color: var(--text);
+      opacity: 0.5;
+      font-size: 14px;
+      line-height: 1;
+    }
+    .wn-item.wn-open .wn-chev { transform: rotate(90deg); color: var(--accent); opacity: 1; }
     .wn-expandable > .whats-new-entry { cursor: pointer; border-radius: 6px; }
     .wn-expandable > .whats-new-entry:hover { background: var(--surface2); }
+    .wn-expandable > .whats-new-entry:hover .wn-chev { color: var(--accent); opacity: 1; }
     .wn-expandable > .whats-new-entry:focus-visible {
       outline: 1px solid var(--accent); outline-offset: -1px;
     }
@@ -2700,7 +2705,7 @@ Content-Type: application/json
       const fresh  = c.date >= cutoff24h ? ' wn-fresh' : '';
       const inner  = _wnDetailInner(c);
       const exp    = inner !== '';
-      const handlers = exp ? ' role="button" tabindex="0" onclick="_wnToggle(this)" onkeydown="_wnKey(event,this)"' : '';
+      const handlers = exp ? ' role="button" tabindex="0" aria-expanded="false" title="Show details" onclick="_wnToggle(this)" onkeydown="_wnKey(event,this)"' : '';
       return `<div class="wn-item${exp ? ' wn-expandable' : ''}">` +
         `<div class="whats-new-entry type-${gcls}${fresh}" data-idx="${startIdx + i}"${handlers}>` +
           `<span class="wn-fresh-dot"></span>` +
@@ -2724,6 +2729,7 @@ Content-Type: application/json
     if (!detail) return;
     const open = item.classList.toggle('wn-open');
     detail.hidden = !open;
+    rowEl.setAttribute('aria-expanded', String(open));
   }
 
   function _wnKey(e, rowEl) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -854,17 +854,43 @@
       font-size: 14px;
     }
 
-    /* Inline "what exactly changed" detail shown under the summary row. */
-    .wn-detail {
-      padding: 2px 0 10px 26px;
-      display: flex;
-      flex-direction: column;
-      gap: 3px;
+    /* Expandable rows: chevron affordance + click-to-open detail. */
+    .wn-chev, .wn-chev-spacer {
+      width: 12px;
+      flex-shrink: 0;
+      color: var(--muted);
+      font-size: 11px;
+      text-align: center;
+      transition: transform 0.18s ease;
     }
+    .wn-item.wn-open .wn-chev { transform: rotate(90deg); }
+    .wn-expandable > .whats-new-entry { cursor: pointer; border-radius: 6px; }
+    .wn-expandable > .whats-new-entry:hover { background: var(--surface2); }
+    .wn-expandable > .whats-new-entry:focus-visible {
+      outline: 1px solid var(--accent); outline-offset: -1px;
+    }
+
+    /* Expanded "what exactly changed" detail (block flow — not flex column). */
+    .wn-detail { padding: 2px 0 12px 26px; }
+    .wn-detail[hidden] { display: none; }
+
+    .wn-pgroup { margin-top: 8px; }
+    .wn-pgroup:first-child { margin-top: 2px; }
+    .wn-phead {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-bottom: 4px;
+      opacity: 0.85;
+    }
+    .wn-phead.added   { color: var(--accent); }
+    .wn-phead.removed { color: var(--danger); }
     .wn-perm {
+      display: block;
       font-family: var(--font-mono);
       font-size: 11.5px;
-      line-height: 1.45;
+      line-height: 1.55;
       color: var(--muted);
       word-break: break-all;
     }
@@ -873,8 +899,7 @@
     .wn-perm .wn-sign { display: inline-block; width: 12px; font-weight: 700; }
     .wn-perm-rest[hidden] { display: none; }
     .wn-more-btn {
-      align-self: flex-start;
-      margin-top: 3px;
+      margin-top: 4px;
       background: none;
       border: 1px solid var(--border);
       border-radius: 6px;
@@ -885,6 +910,7 @@
       cursor: pointer;
     }
     .wn-more-btn:hover { color: var(--text); border-color: var(--muted); }
+
     /* Word-level diff: full text in context, only changed words highlighted. */
     .wn-worddiff {
       font-family: var(--font-body);
@@ -2628,29 +2654,31 @@ Content-Type: application/json
     return s;
   }
 
-  // Renders one permission group (added or removed), capping at _WN_PERM_CAP
-  // with a "+N more" toggle for the remainder.
-  function _wnPermGroup(perms, cls, sign) {
+  // One permission section (Added / Removed) with a header + count, capping at
+  // _WN_PERM_CAP rows with a "+N more" toggle for the remainder.
+  function _wnPermSection(perms, cls, sign, title) {
     if (!perms || !perms.length) return '';
     const row  = p => `<div class="wn-perm ${cls}"><span class="wn-sign">${sign}</span>${esc(p)}</div>`;
     const head = perms.slice(0, _WN_PERM_CAP).map(row).join('');
     const rest = perms.slice(_WN_PERM_CAP);
-    if (!rest.length) return head;
-    const id = `wnp-${_wnUid++}`;
-    return head +
-      `<div class="wn-perm-rest" id="${id}" hidden>${rest.map(row).join('')}</div>` +
-      `<button class="wn-more-btn" onclick="_wnMore('${id}', this)">+${rest.length} more</button>`;
+    let body = head;
+    if (rest.length) {
+      const id = `wnp-${_wnUid++}`;
+      body += `<div class="wn-perm-rest" id="${id}" hidden>${rest.map(row).join('')}</div>` +
+        `<button class="wn-more-btn" onclick="_wnMore('${id}', this)">+${rest.length} more</button>`;
+    }
+    return `<div class="wn-pgroup ${cls}"><div class="wn-phead ${cls}">${title} (${perms.length})</div>${body}</div>`;
   }
 
-  // Inline detail block under a summary row. Permission changes list the actual
-  // added/removed permissions; scalar changes (description, privileged, rename)
-  // show before → after. Falls back gracefully for historical entries that
-  // predate the structured fields.
-  function _wnDetailHtml(c) {
+  // Inner detail HTML revealed when a row is expanded ('' = nothing to expand).
+  // Permission changes list the added (green) / removed (red) permissions;
+  // description/rename show a word-level diff. isPrivileged is conveyed solely
+  // by the row badge. Historical permission entries (counts only, no names)
+  // return '' and stay non-expandable.
+  function _wnDetailInner(c) {
     if (c.field === 'permissions') {
-      const detail = _wnPermGroup(c.added_permissions, 'added', '+') +
-                     _wnPermGroup(c.removed_permissions, 'removed', '−');
-      return detail ? `<div class="wn-detail">${detail}</div>` : '';
+      return _wnPermSection(c.added_permissions, 'added', '+', 'Added') +
+             _wnPermSection(c.removed_permissions, 'removed', '−', 'Removed');
     }
     if (c.field === 'description' || c.field === 'displayName') {
       let oldV = c.old, newV = c.new;
@@ -2659,9 +2687,8 @@ Content-Type: application/json
         if (m) { oldV = _unquote(m[1]); newV = _unquote(m[2]); }
       }
       if (oldV === undefined && newV === undefined) return '';
-      return `<div class="wn-detail wn-worddiff">${_wnDiffWords(String(oldV ?? ''), String(newV ?? ''))}</div>`;
+      return `<div class="wn-worddiff">${_wnDiffWords(String(oldV ?? ''), String(newV ?? ''))}</div>`;
     }
-    // isPrivileged is fully conveyed by the row badge — no detail block.
     return '';
   }
 
@@ -2671,17 +2698,36 @@ Content-Type: application/json
       const glyph  = _WN_GLYPHS[type] ?? '•';
       const gcls   = _WN_GLYPH_CLASS[type] ?? '';
       const fresh  = c.date >= cutoff24h ? ' wn-fresh' : '';
-      return `<div class="wn-item">` +
-        `<div class="whats-new-entry type-${gcls}${fresh}" data-idx="${startIdx + i}">` +
+      const inner  = _wnDetailInner(c);
+      const exp    = inner !== '';
+      const handlers = exp ? ' role="button" tabindex="0" onclick="_wnToggle(this)" onkeydown="_wnKey(event,this)"' : '';
+      return `<div class="wn-item${exp ? ' wn-expandable' : ''}">` +
+        `<div class="whats-new-entry type-${gcls}${fresh}" data-idx="${startIdx + i}"${handlers}>` +
           `<span class="wn-fresh-dot"></span>` +
           `<span class="wn-glyph ${gcls}">${glyph}</span>` +
           `<span class="wn-name">${esc(c.role_name ?? '')}</span>` +
           `<span class="wn-action">${_wnActionHtml(c)}</span>` +
           `<span class="wn-date">${esc(c.date ?? '')}</span>` +
+          (exp ? `<span class="wn-chev">▸</span>` : `<span class="wn-chev-spacer"></span>`) +
         `</div>` +
-        _wnDetailHtml(c) +
+        (exp ? `<div class="wn-detail" hidden>${inner}</div>` : '') +
         `</div>`;
     }).join('');
+  }
+
+  // Expand/collapse a single row's detail. The summary row and its detail are
+  // siblings, so clicks inside the detail (e.g. "+N more") don't toggle it.
+  function _wnToggle(rowEl) {
+    const item = rowEl.closest('.wn-item');
+    if (!item) return;
+    const detail = item.querySelector('.wn-detail');
+    if (!detail) return;
+    const open = item.classList.toggle('wn-open');
+    detail.hidden = !open;
+  }
+
+  function _wnKey(e, rowEl) {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); _wnToggle(rowEl); }
   }
 
   function _wnMore(id, btn) {


### PR DESCRIPTION
## What's new — click to expand, with real permission detail

Reworks the panel per feedback: collapsed, scannable rows that **expand on click** to show exactly what changed — **removed permissions in red, added in green**.

### Changes
- **Click-to-expand rows.** Each change is a tidy one-liner (role · label/badges · date) with a chevron; clicking (or Enter/Space) reveals the detail. Rows with nothing to show aren't expandable.
- **Permission detail on expand** — `Added (N)` in green and `Removed (N)` in red, listing the actual `microsoft.directory/…` permissions, capped at 8 per section with **"+N more"**.
- **Word-level description diff** (fixed) — renders inline in context with only the changed words highlighted, instead of the previous full-width green bars.
- **Privileged badge** — `now privileged` / `no longer privileged`, no redundant detail.
- **Backfilled `data/changelog.json`** — reconstructed the added/removed permission **names** for every historical entry by replaying the diff across `data/roles.json` git snapshots (04-14 → 06-17). Verified 18/18 entries reproduce the live counts exactly, so the *existing* rows are expandable immediately, not just future ones. Backfill only **adds** fields; dates/order/detail are unchanged.

### Verified
Page JS parses (`node --check`); render-tested against the backfilled data — permission rows expand to red/green sections, Global Admin's 19 removals show "+11 more", description expands to a word diff, privileged is badge-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
