### PR TITLE
fix(whats-new): gap between adjacent strikethrough/insert in word diff

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -937,6 +937,10 @@
       opacity: 0.7;
       padding: 0 1px;
     }
+    /* When a deletion sits directly against an insertion (the connecting space
+       fell to one side), add a small gap so they don't read as one word. */
+    .wn-worddiff del + ins,
+    .wn-worddiff ins + del { margin-left: 5px; }
 
     /* Count badges in the summary row (+N added / −N removed, privileged). */
     .wn-badges { display: inline-flex; gap: 5px; align-items: center; }


### PR DESCRIPTION
Cosmetic: when a deleted word sits directly against an inserted word (the connecting space fell to one side of the diff), they read as one blob — e.g. "service" + "identity" rendered as "serviceidentity". Adds a 5px gap precisely at a `del + ins` / `ins + del` boundary, leaving normal word spacing untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)