### PR TITLE
fix(whats-new): robust word-diff spacing (real space, not CSS margin)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -937,10 +937,8 @@
       opacity: 0.7;
       padding: 0 1px;
     }
-    /* When a deletion sits directly against an insertion (the connecting space
-       fell to one side), add a small gap so they don't read as one word. */
-    .wn-worddiff del + ins,
-    .wn-worddiff ins + del { margin-left: 5px; }
+    /* A deletion replaced by an insertion is separated by a real space in the
+       markup (see _wnDiffWords), so no extra margin is needed. */
 
     /* isPrivileged change: a plain Was / Now layout (no strikethrough) + why. */
     .wn-privnote { font-family: var(--font-body); }
@@ -2663,8 +2661,13 @@ Content-Type: application/json
         dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
     let i = 0, j = 0, out = '', del = '', ins = '';
     const flush = () => {
-      if (del) { out += `<del>${esc(del)}</del>`; del = ''; }
-      if (ins) { out += `<ins>${esc(ins)}</ins>`; ins = ''; }
+      // A deletion that is replaced by an insertion at the same spot: separate
+      // them with a real space so "service" + "identity" reads as two words,
+      // not "serviceidentity".
+      if (del && ins) { out += `<del>${esc(del)}</del> <ins>${esc(ins)}</ins>`; }
+      else if (del)   { out += `<del>${esc(del)}</del>`; }
+      else if (ins)   { out += `<ins>${esc(ins)}</ins>`; }
+      del = ''; ins = '';
     };
     while (i < n && j < m) {
       if (a[i] === b[j]) { flush(); out += esc(a[i]); i++; j++; }


### PR DESCRIPTION
The 5px CSS margin between an adjacent deletion/insertion wasn't reading as a real gap in production (service↔identity still looked merged). Replaces it with an actual space character in the markup between a deleted word and the insertion that replaces it, so it renders with natural word spacing: "agent service identity blueprint principals". Removed the now-redundant margin rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)