### PR TITLE
fix(whats-new): red/green chips for word diff (clear removed vs added)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -923,19 +923,22 @@
       color: var(--muted);
       line-height: 1.6;
     }
+    .wn-worddiff ins,
+    .wn-worddiff del {
+      border-radius: 3px;
+      padding: 1px 5px;
+      margin: 0 1px;
+    }
     .wn-worddiff ins {
       text-decoration: none;
       color: var(--accent);
-      background: rgba(0, 229, 163, 0.13);
-      border-radius: 3px;
-      padding: 0 2px;
+      background: rgba(0, 229, 163, 0.15);
     }
     .wn-worddiff del {
       text-decoration: line-through;
       text-decoration-thickness: 1px;
       color: var(--danger);
-      opacity: 0.7;
-      padding: 0 1px;
+      background: rgba(248, 113, 113, 0.15);
     }
     /* A deletion replaced by an insertion is separated by a real space in the
        markup (see _wnDiffWords), so no extra margin is needed. */


### PR DESCRIPTION
The deleted word had only faint strikethrough text (no background), so it blended into the adjacent green insertion chip — a ~4px gap wasn't enough to separate them. Now deletions get a red chip background and insertions a green chip (GitHub-style inline diff), both padded with a real space between. "service" reads as a clearly red, struck-through chip; "identity" / "blueprint" as green chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)