### PR TITLE
fix(coverage): exclude implicit/system roles so the issue stays actionable

### DIFF
--- a/pipeline/coverage_report.py
+++ b/pipeline/coverage_report.py
@@ -38,6 +38,27 @@ GH_API = "https://api.github.com"
 ISSUE_TITLE = "Roles awaiting task coverage"
 ISSUE_LABEL = "coverage"
 
+# Implicit / default / system directory roles that Microsoft does not list on
+# the delegate-by-task page and never will (default user buckets, device
+# registration roles, sync/service accounts). They legitimately have no task,
+# so they are excluded from the actionable "needs attention" list — otherwise
+# the coverage issue could never reach empty. They still appear in the full
+# data/coverage.json breakdown.
+IMPLICIT_ROLES = {
+    "user",
+    "guest user",
+    "restricted guest user",
+    "device join",
+    "workplace device join",
+    "device users",
+    "device managers",
+    "device administrators",
+    "on premises directory sync account",
+    "directory synchronization accounts",
+    "partner tier1 support",
+    "partner tier2 support",
+}
+
 
 def load(path: Path, default=None):
     if not path.exists():
@@ -172,7 +193,11 @@ def main() -> None:
     recent_ids = recently_added_ids(changelog, cutoff)
 
     attention = sorted(
-        (_slim(r) for r in uncovered if r.get("isShadowRole") or r.get("id") in recent_ids),
+        (
+            _slim(r) for r in uncovered
+            if (r.get("isShadowRole") or r.get("id") in recent_ids)
+            and r.get("displayName", "").strip().lower() not in IMPLICIT_ROLES
+        ),
         key=lambda r: r["displayName"].lower(),
     )
 


### PR DESCRIPTION
The coverage issue was flagging implicit/default/system roles (User, Guest User, Restricted Guest User, the Device * registration roles, On Premises Directory Sync Account) that Microsoft will never put on the delegate-by-task page — so the issue could never reach empty. These are now excluded from the actionable 'needs attention' list (they remain in the full data/coverage.json breakdown). Result on current data: 13 → 5 genuinely actionable roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)