### PR TITLE
fix: future-proof workload/zero-permission roles (generic note + coverage exclusion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A role only appears as a least-privilege *recommendation* once a task points to 
 `coverage_report.py` runs every night and:
 
 - writes [`data/coverage.json`](data/coverage.json) with the full breakdown (covered vs. uncovered roles), and
-- maintains a single idempotent **[Roles awaiting task coverage](https://github.com/arusso-aboutcloud/entra-rolelens/issues?q=label%3Acoverage)** issue listing only the *new/undocumented* roles that still need a task — updated each run and closed automatically when the list is empty.
+- maintains a single idempotent **[Roles awaiting task coverage](https://github.com/arusso-aboutcloud/entra-rolelens/issues?q=label%3Acoverage)** issue listing only the *new/undocumented* roles that still need a task — updated each run and closed automatically when the list is empty. Implicit/default directory roles and **zero-permission workload roles** (e.g. Purview content roles, which grant no Entra directory actions and are governed in their own service portal) are excluded — they can't take a task mapping.
 
 This keeps the one remaining manual step — seeding a task for a role Microsoft hasn't documented yet — explicit and visible, rather than silent.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2836,9 +2836,12 @@ Content-Type: application/json
       const perms = role.permissions || [];
       let html = '';
       if (role.description) html += `<div class="wn-role-desc">${esc(role.description)}</div>`;
+      // Service-agnostic note: any role with zero Entra directory actions is a
+      // workload role governed in its own service (the description above names
+      // which). Don't hardcode a specific product here.
       html += perms.length
         ? _wnPermList(perms)
-        : `<div class="wn-role-note">No Entra directory permissions — this role is assigned and managed outside Entra (e.g. via the Microsoft Purview portal).</div>`;
+        : `<div class="wn-role-note">No Entra directory permissions — this role grants no Entra directory actions; it's assigned and managed in its own service portal, not the Entra admin center.</div>`;
       container.innerHTML = html;
     } catch {
       container.removeAttribute('data-loaded'); // allow retry on next open

--- a/pipeline/coverage_report.py
+++ b/pipeline/coverage_report.py
@@ -197,6 +197,12 @@ def main() -> None:
             _slim(r) for r in uncovered
             if (r.get("isShadowRole") or r.get("id") in recent_ids)
             and r.get("displayName", "").strip().lower() not in IMPLICIT_ROLES
+            # Property-based, future-proof: a role with zero Entra directory
+            # actions (e.g. Purview/other workload roles governed in their own
+            # service portal) can never be a least-privilege answer for a task,
+            # so it never "needs task coverage". Excludes all such roles by
+            # nature, not by name.
+            and len(r.get("permissions") or []) > 0
         ),
         key=lambda r: r["displayName"].lower(),
     )


### PR DESCRIPTION
Makes the new-role handling fully self-scaling instead of Purview-flavored.

- **Frontend**: the 0-permission note is now **service-agnostic** — "grants no Entra directory actions; managed in its own service portal" — instead of naming the Microsoft Purview portal. The role's own description (shown above the note) names the actual service, so this is correct for any future workload role (Defender, Intune, Fabric, …).
- **coverage_report.py**: exclude **zero-permission roles** from the 'awaiting task coverage' list — **property-based, not by name**. A role that grants no Entra directory actions can never be a least-privilege answer for a task, so it should never be flagged. Auto-handles every future workload role; issue #86 drops 5 → 2 (Customer Delegated Admin + Entra Customer Lockbox Approver, both of which actually grant permissions).
- **README**: documents the exclusion for transparency.

Verified: coverage_report compiles + now reports 2 attention roles; frontend JS parses; note no longer references a specific product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)