### PR TITLE
chore: keep README and frontend 'new' window (30d) in sync

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2206,6 +2206,7 @@
   // this many days after it was added — also the What's-new panel history span.
   // (The 24h "fresh" dot is a separate finer signal; coverage uses its own
   // longer lead-time window server-side.)
+  // Mirror this value in pipeline/push_to_cloudflare.py (README "What's new" feed).
   const NEW_ROLE_DAYS = 30;
   const _newRoleIds = new Set();
   function isNewRole(roleId) {

--- a/pipeline/push_to_cloudflare.py
+++ b/pipeline/push_to_cloudflare.py
@@ -436,7 +436,11 @@ def update_readme_whats_new(changelog_path: Path, readme_path: Path) -> None:
     with open(changelog_path, encoding="utf-8") as f:
         changelog = json.load(f)
 
-    cutoff = (datetime.utcnow() - timedelta(days=30)).date().isoformat()
+    # "New" window for the README feed. Keep in sync with the frontend's
+    # NEW_ROLE_DAYS constant (frontend/index.html) so the README and the live
+    # "What's new" panel agree on how long an entry is considered new.
+    NEW_ROLE_DAYS = 30
+    cutoff = (datetime.utcnow() - timedelta(days=NEW_ROLE_DAYS)).date().isoformat()
     recent = [c for c in changelog if c.get("date", "") >= cutoff]
 
     if not recent:


### PR DESCRIPTION
The README 'What's new' feed and the frontend both use a 30-day 'new' window but hardcoded it independently (different languages, can't share a constant). Names it (`NEW_ROLE_DAYS = 30`) in `push_to_cloudflare.py` and adds cross-reference comments both ways so the two stay in sync if the window ever changes. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)