### PR TITLE
fix: union permission sources (accurate role detail/diff) + newest-first What's new

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2889,7 +2889,13 @@ Content-Type: application/json
       const cutoff   = new Date(Date.now() - NEW_ROLE_DAYS * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
       const today    = new Date().toISOString().slice(0, 10);
       const cutoff24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-      const recent   = changelog.filter(c => c.date >= cutoff).slice(0, 50);
+      // Newest first: the changelog is stored oldest→newest (append log), so
+      // sort descending by date so the most recent changes sit at the top and
+      // are visible without expanding.
+      const recent   = changelog
+        .filter(c => c.date >= cutoff)
+        .sort((a, b) => (b.date || '').localeCompare(a.date || ''))
+        .slice(0, 50);
       if (!recent.length) return;
 
       const todayItems = recent.filter(c => c.date >= today);

--- a/pipeline/enrich.py
+++ b/pipeline/enrich.py
@@ -85,10 +85,17 @@ def build_merged_roles(
         docs_role = docs_by_id.get(role_id)
 
         # Flatten permissions from Graph API structure
-        permissions = flatten_graph_permissions(graph_role)
+        graph_permissions = flatten_graph_permissions(graph_role)
 
         if docs_role:
-            # Known role — merge, prefer docs for isPrivileged and description
+            # Reconcile the two permission sources. The Graph roleDefinition and
+            # the docs permissions-reference can each lead during Microsoft rollout
+            # windows: docs lead for brand-new roles (e.g. AI Administrator's
+            # agentIdentities/* set), Graph leads for some mature roles. Take the
+            # UNION so the catalog never *under*-states what a role grants — the
+            # safe direction for a least-privilege tool, and it keeps the worker's
+            # role detail/diff/search consistent with the docs-based "What's new".
+            permissions = sorted(set(graph_permissions) | set(docs_role.get("permissions", [])))
             merged.append({
                 "id":           role_id,
                 "displayName":  graph_role.get("displayName", docs_role.get("displayName", "")),
@@ -99,7 +106,7 @@ def build_merged_roles(
                 "isShadowRole": False,
             })
         else:
-            # Shadow role — present in API, absent from docs
+            # Shadow role — present in API, absent from docs (Graph is all we have)
             display_name = graph_role.get("displayName", role_id)
             shadow_names.append(display_name)
             merged.append({
@@ -108,7 +115,7 @@ def build_merged_roles(
                 "description":  graph_role.get("description", ""),
                 "isBuiltIn":    graph_role.get("isBuiltIn", True),
                 "isPrivileged": False,
-                "permissions":  permissions,
+                "permissions":  graph_permissions,
                 "isShadowRole": True,
             })
 

--- a/pipeline/push_to_cloudflare.py
+++ b/pipeline/push_to_cloudflare.py
@@ -441,7 +441,14 @@ def update_readme_whats_new(changelog_path: Path, readme_path: Path) -> None:
     # "What's new" panel agree on how long an entry is considered new.
     NEW_ROLE_DAYS = 30
     cutoff = (datetime.utcnow() - timedelta(days=NEW_ROLE_DAYS)).date().isoformat()
-    recent = [c for c in changelog if c.get("date", "") >= cutoff]
+    # Newest first: the changelog is stored oldest→newest, so sort descending by
+    # date before taking the top slice — the most recent changes lead the list
+    # (matches the app's "What's new" panel ordering).
+    recent = sorted(
+        (c for c in changelog if c.get("date", "") >= cutoff),
+        key=lambda c: c.get("date", ""),
+        reverse=True,
+    )
 
     if not recent:
         return


### PR DESCRIPTION
## Accurate permissions (union of both sources) + newest-first "What's new"

### 1. Fix: catalog no longer under-states role permissions (`enrich.py`)
The worker (search / role-diff / role-detail) was built from the **Graph API** permission set, while "What's new" used the **docs**. They diverge during Microsoft rollout windows — worst case **AI Administrator showed 30 perms in the app but 70 in the docs** (missing the entire `agentIdentities/*` set the 06-26 change added), and its diff even showed AI *Reader* with more perms than the *Administrator*.

`enrich.py` now reconciles both sources with a **union** per role, so the catalog never *under*-states what a role grants — the safe direction for a least-privilege tool. Verified locally against live data:

| Role | before (Graph) | after (union) |
|---|---|---|
| AI Administrator | 30 | **70** (39 `agentIdentities/*`) |
| Tenant Governance Administrator | 7 | **24** |
| Tenant Governance Reader | 1 | **7** |
| Global Administrator | 257 | **257** (keeps its Graph-only extras) |
| Purview Workload Content ×3 | 0 | **0** (union of 0+0 — coverage exclusion intact) |

Role/task counts unchanged (`validate` passes); shadow roles unchanged; contained to one file, reversible. No worker code, diff logic, changelog, or pipeline-ordering change → **no spurious "everything changed" diff**. The pipeline's `test_pills.py` will catch any least-privilege *ranking* regression from the more-accurate counts.

> Takes effect after the next pipeline run (or a manual dispatch) regenerates `master.json` → D1.

### 2. Feature: newest changes first in "What's new" (app + README)
The changelog is stored oldest→newest, so recent changes sat at the **bottom** and needed expanding. Now both the **app panel** (`frontend/index.html`) and the **README feed** (`push_to_cloudflare.py`) sort **descending by date** — the most recent change leads the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
