### PR TITLE
feat: Trivy SecDevOps night-rider (replaces Code Quality bar) + daily security feed

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -20,6 +20,7 @@ jobs:
       contents: write
       issues: write
       id-token: write # MANDATORY: Allows GitHub to request the OIDC token from Entra
+      security-events: read # read Trivy code-scanning alerts for the app's security strip
 
     steps:
       - name: Harden Runner
@@ -73,6 +74,12 @@ jobs:
 
       - name: Role task-coverage report
         run: python pipeline/coverage_report.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Security scan summary
+        run: python pipeline/security_summary.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO: ${{ github.repository }}

--- a/data/security.json
+++ b/data/security.json
@@ -1,0 +1,10 @@
+{
+  "scanned_at": "2026-07-03T13:36:08.931704+00:00",
+  "tool": "Trivy",
+  "critical": 0,
+  "high": 0,
+  "medium": 0,
+  "low": 0,
+  "total": 0,
+  "status": "clean"
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1263,41 +1263,58 @@
     .gh-stat-sep { color: var(--border); user-select: none; }
 
     /* ── Sentrux quality strip ──────────────────────────────────────── */
-    .sentrux-bar {
+    /* ── SecDevOps security strip (Trivy) — night-rider ──────────────── */
+    .secops-bar {
+      display: flex;
       align-items: center;
-      gap: 10px;
+      gap: 12px;
       margin-bottom: 20px;
+      padding: 7px 14px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent);
       font-family: var(--font-mono);
       font-size: 11px;
-      color: var(--muted);
-      letter-spacing: 0.4px;
+      letter-spacing: 0.5px;
+      width: fit-content;
+      max-width: 100%;
     }
-    .sentrux-track {
-      position: relative;
-      width: 160px;
-      height: 4px;
-      background: var(--border);
-      border-radius: 2px;
-      overflow: hidden;
-      flex-shrink: 0;
+    .secops-icon  { font-size: 13px; line-height: 1; }
+    .secops-label { color: var(--muted); font-weight: 600; text-transform: uppercase; }
+    .secops-status {
+      display: inline-flex; align-items: center; gap: 6px;
+      font-weight: 700; text-transform: uppercase; white-space: nowrap;
     }
-    .sentrux-fill {
-      position: absolute;
-      left: 0; top: 0; bottom: 0;
-      background: linear-gradient(90deg, var(--border) 0%, rgba(0,229,163,0.55) 100%);
-      border-radius: 2px;
+    .secops-dot {
+      width: 7px; height: 7px; border-radius: 50%;
+      background: currentColor; box-shadow: 0 0 8px currentColor; flex-shrink: 0;
     }
-    .sentrux-beam {
-      position: absolute;
-      top: 0; bottom: 0;
-      width: 50px;
-      background: linear-gradient(90deg, transparent 0%, rgba(0,229,163,0.45) 25%, rgba(255,255,255,0.88) 50%, rgba(0,229,163,0.45) 75%, transparent 100%);
-      animation: kitt 2.4s linear infinite;
+    @media (prefers-reduced-motion: no-preference) {
+      .secops-dot { animation: secops-pulse 1.8s ease-in-out infinite; }
     }
-    @keyframes kitt {
-      from { left: -50px; }
-      to   { left: 160px; }
+    @keyframes secops-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }
+    .secops-track {
+      position: relative; width: 150px; height: 4px;
+      background: var(--border); border-radius: 2px; overflow: hidden; flex-shrink: 0;
     }
+    .secops-fill {
+      position: absolute; left: 0; top: 0; bottom: 0; width: 100%;
+      background: linear-gradient(90deg, transparent, currentColor);
+      opacity: 0.3; border-radius: 2px;
+    }
+    .secops-beam {
+      position: absolute; top: 0; bottom: 0; width: 44px;
+      background: linear-gradient(90deg, transparent 0%, currentColor 42%, #fff 50%, currentColor 58%, transparent 100%);
+    }
+    @media (prefers-reduced-motion: no-preference) {
+      .secops-beam { animation: kitt 2.2s linear infinite; }
+    }
+    @keyframes kitt { from { left: -44px; } to { left: 150px; } }
+    .secops-meta { color: var(--dim); font-size: 10px; white-space: nowrap; }
+    /* state → currentColor drives dot / beam / fill / status text */
+    .secops-bar[data-state="clean"]   { color: var(--accent); }
+    .secops-bar[data-state="issues"]  { color: var(--danger); }
+    .secops-bar[data-state="unknown"] { color: var(--muted); }
 
     /* ── Diff description + example pills ──────────────────────────── */
     .diff-desc {
@@ -1473,14 +1490,15 @@
       <div class="gh-stats-bar" id="gh-stats"></div>
 
       <!-- Sentrux quality strip -->
-      <div class="sentrux-bar" id="sentrux-bar" style="display:none">
-        <span style="color:var(--dim);user-select:none">◈</span>
-        <span style="color:var(--dim)">Code Quality</span>
-        <span id="sentrux-score" style="color:var(--muted)">—</span>
-        <div class="sentrux-track">
-          <div class="sentrux-fill" id="sentrux-fill" style="width:0%"></div>
-          <div class="sentrux-beam"></div>
+      <div class="secops-bar" id="secops-bar" data-state="unknown" style="display:none" title="Trivy vulnerability scan — from GitHub code scanning, refreshed daily">
+        <span class="secops-icon">🛡</span>
+        <span class="secops-label">Trivy</span>
+        <span class="secops-status" id="secops-status">—</span>
+        <div class="secops-track">
+          <div class="secops-fill"></div>
+          <div class="secops-beam"></div>
         </div>
+        <span class="secops-meta" id="secops-meta"></span>
       </div>
 
       <!-- What's new panel -->
@@ -1733,6 +1751,8 @@
       document.getElementById('stat-tasks').textContent = newTasks;
       document.getElementById('stat-pipeline').textContent =
         'Pipeline ' + (d.pipeline === 'healthy' ? 'healthy' : d.pipeline ?? 'unknown');
+
+      renderSecurity(d.security);
 
       const shadowCount = d.shadow_role_count ?? 0;
       if (shadowCount > 0) {
@@ -2959,25 +2979,36 @@ Content-Type: application/json
     chevron.classList.toggle('open', !open);
   }
 
-  // ── Sentrux quality strip ─────────────────────────────────────────────
-  async function loadQuality() {
-    try {
-      const res = await fetch(API + '/api/quality');
-      if (!res.ok) return;
-      const { metrics, has_data } = await res.json();
-      if (!has_data) return;
-      const score = metrics.quality ?? null;
-      if (score === null) return;
-      const pct = Math.min(100, (score / 10000) * 100).toFixed(1);
-      document.getElementById('sentrux-fill').style.width = pct + '%';
-      document.getElementById('sentrux-score').textContent = score.toLocaleString() + ' / 10 000';
-      document.getElementById('sentrux-bar').style.display = 'flex';
-    } catch (_) {}
+  // ── Trivy security strip (SecDevOps night-rider) ──────────────────────
+  // Fed by /api/status → security (Trivy code-scanning posture, refreshed daily).
+  function renderSecurity(sec) {
+    const bar = document.getElementById('secops-bar');
+    if (!bar) return;
+    sec = sec || {};
+    const statusEl = document.getElementById('secops-status');
+    const metaEl   = document.getElementById('secops-meta');
+    const st = sec.status || 'unknown';
+    if (st === 'clean') {
+      bar.dataset.state = 'clean';
+      statusEl.innerHTML = '<span class="secops-dot"></span>Clean';
+    } else if (st === 'issues') {
+      bar.dataset.state = 'issues';
+      const parts = [];
+      if (sec.critical) parts.push(sec.critical + ' Critical');
+      if (sec.high)     parts.push(sec.high + ' High');
+      if (sec.medium)   parts.push(sec.medium + ' Medium');
+      statusEl.innerHTML = '<span class="secops-dot"></span>' + (parts.join(' · ') || (sec.total + ' issues'));
+    } else {
+      bar.dataset.state = 'unknown';
+      statusEl.innerHTML = '<span class="secops-dot"></span>Scanning…';
+    }
+    metaEl.textContent = sec.scanned_at ? 'code scan · ' + sec.scanned_at.slice(0, 10) : 'awaiting scan';
+    bar.style.display = 'flex';
   }
 
   // ── Boot ─────────────────────────────────────────────────────────────
   (async () => {
-    await Promise.all([loadStatus(), loadRoles(), loadGitHubStats(), loadWhatsNew(), loadQuality()]);
+    await Promise.all([loadStatus(), loadRoles(), loadGitHubStats(), loadWhatsNew()]);
     setInterval(loadStatus, 60000);
   })();
 </script>

--- a/pipeline/push_to_cloudflare.py
+++ b/pipeline/push_to_cloudflare.py
@@ -222,19 +222,32 @@ def d1_run_many(account_id: str, database_id: str, token: str,
 # Push: KV
 # ---------------------------------------------------------------------------
 
+def _load_security() -> dict | None:
+    """Trivy security posture written by security_summary.py (optional)."""
+    path = DATA_DIR / "security.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
 def push_kv(account_id: str, namespace_id: str, token: str,
             master: dict) -> None:
     print("Pushing to Cloudflare KV...")
     kv_put(account_id, namespace_id, token,
            "master", json.dumps(master, ensure_ascii=False))
+    status = {
+        "last_updated": TODAY,
+        "role_count": master["role_count"],
+        "task_count": master["task_count"],
+        "shadow_role_count": master.get("shadow_role_count", 0),
+        "pipeline": "healthy",
+    }
+    security = _load_security()
+    if security:
+        status["security"] = security
     kv_put(account_id, namespace_id, token,
-           "pipeline_status", json.dumps({
-               "last_updated": TODAY,
-               "role_count": master["role_count"],
-               "task_count": master["task_count"],
-               "shadow_role_count": master.get("shadow_role_count", 0),
-               "pipeline": "healthy",
-           }))
+           "pipeline_status", json.dumps(status))
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/security_summary.py
+++ b/pipeline/security_summary.py
@@ -1,0 +1,90 @@
+"""
+security_summary.py
+
+Writes data/security.json with the current Trivy vulnerability posture, read
+from GitHub code-scanning (the Trivy SARIF the security workflow uploads). Lets
+the app show a live daily security status. Reflects exactly what's in
+GitHub Security -> Code scanning. Safe on any error: writes an 'unknown' status
+rather than failing the pipeline.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+OUT = Path(__file__).parent.parent / "data" / "security.json"
+GH_API = "https://api.github.com"
+
+
+def fetch_open_alerts(repo: str, token: str) -> list:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    alerts, page = [], 1
+    while True:
+        r = requests.get(
+            f"{GH_API}/repos/{repo}/code-scanning/alerts",
+            headers=headers,
+            params={"state": "open", "per_page": 100, "page": page},
+            timeout=20,
+        )
+        if not r.ok:
+            raise RuntimeError(f"HTTP {r.status_code}: {r.text[:200]}")
+        batch = r.json()
+        alerts.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return alerts
+
+
+def main() -> None:
+    summary = {
+        "scanned_at": datetime.now(timezone.utc).isoformat(),
+        "tool": "Trivy",
+        "critical": 0,
+        "high": 0,
+        "medium": 0,
+        "low": 0,
+        "total": 0,
+        "status": "unknown",
+    }
+
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPO") or os.environ.get("GITHUB_REPOSITORY")
+
+    if token and repo:
+        try:
+            trivy = [
+                a for a in fetch_open_alerts(repo, token)
+                if (a.get("tool") or {}).get("name") == "Trivy"
+            ]
+            for a in trivy:
+                sev = ((a.get("rule") or {}).get("security_severity_level") or "").lower()
+                if sev in ("critical", "high", "medium", "low"):
+                    summary[sev] += 1
+            summary["total"] = len(trivy)
+            summary["status"] = "clean" if summary["total"] == 0 else "issues"
+            print(
+                f"  Trivy code-scanning: {summary['total']} open "
+                f"(C{summary['critical']} H{summary['high']} "
+                f"M{summary['medium']} L{summary['low']}) -> {summary['status']}"
+            )
+        except Exception as exc:  # noqa: BLE001 - never fail the pipeline for this
+            print(f"  WARN: could not read code-scanning alerts ({exc}) — status 'unknown'",
+                  file=sys.stderr)
+    else:
+        print("  (GITHUB_TOKEN/GITHUB_REPO not set — security status 'unknown')")
+
+    OUT.write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Written -> {OUT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Replace Code Quality bar with a Trivy SecDevOps night-rider

Per request: the app's status strip now shows a **live Trivy security posture** instead of the Sentrux code-quality score, restyled as a pro SecDevOps night-rider. Sentrux stays on the GitHub README (dashboard + quality gate) — verified it's working (app and README both show 6859, updated daily; it's flat because structural metrics are clean, not stale).

### Daily security feed (new)
- **`pipeline/security_summary.py`** reads GitHub **code-scanning** (the Trivy SARIF) and writes `data/security.json` with open counts by severity + `status` (clean / issues / unknown). Safe on error → `unknown`, never fails the pipeline.
- **`refresh.yml`**: new "Security scan summary" step (+ `security-events: read`); `data/` already committed.
- **`push_to_cloudflare.py`**: includes `security` in the `pipeline_status` KV → surfaced by `/api/status` (no worker change).

### UI (`frontend/index.html`)
- Removed the Sentrux "Code Quality" bar; added a **`.secops-bar`** night-rider: shield + `TRIVY` + status dot (pulsing) + KITT beam sweep + severity meta.
- Color states via `currentColor`: **clean → green**, **issues → red**, **unknown → muted**. Fed from `/api/status.security` on load + every 60s.

### Verify
- Frontend JS parses; 0 leftover Sentrux refs; `push_to_cloudflare` compiles; `refresh.yml` valid; `security_summary.py` verified against live code-scanning (**0 open → clean**); render tested (clean / issues / unknown).
- **DEV link** shows the strip + animation; the live "Clean" (green) state populates after the pipeline runs (I'll dispatch on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
