### PR TITLE
style(secops): more prominent, glowing shield + TRIVY label

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1280,9 +1280,11 @@
       max-width: 100%;
     }
     .secops-icon  {
-      font-size: 16px; line-height: 1;
-      filter: drop-shadow(0 0 6px currentColor);
+      display: inline-flex; line-height: 1;
+      color: currentColor;
+      filter: drop-shadow(0 0 7px currentColor);
     }
+    .secops-icon svg { display: block; }
     .secops-label {
       color: currentColor;
       font-weight: 700;
@@ -1501,7 +1503,7 @@
 
       <!-- Sentrux quality strip -->
       <div class="secops-bar" id="secops-bar" data-state="unknown" style="display:none" title="Trivy vulnerability scan — from GitHub code scanning, refreshed daily">
-        <span class="secops-icon">🛡</span>
+        <span class="secops-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M12 2 4 5v6c0 5 3.4 8.5 8 10 4.6-1.5 8-5 8-10V5l-8-3z"/></svg></span>
         <span class="secops-label">Trivy</span>
         <span class="secops-status" id="secops-status">—</span>
         <div class="secops-track">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1279,8 +1279,18 @@
       width: fit-content;
       max-width: 100%;
     }
-    .secops-icon  { font-size: 13px; line-height: 1; }
-    .secops-label { color: var(--muted); font-weight: 600; text-transform: uppercase; }
+    .secops-icon  {
+      font-size: 16px; line-height: 1;
+      filter: drop-shadow(0 0 6px currentColor);
+    }
+    .secops-label {
+      color: currentColor;
+      font-weight: 700;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 1.2px;
+      text-shadow: 0 0 9px currentColor;
+    }
     .secops-status {
       display: inline-flex; align-items: center; gap: 6px;
       font-weight: 700; text-transform: uppercase; white-space: nowrap;


### PR DESCRIPTION
Makes the 🛡 shield (16px + drop-shadow glow) and the TRIVY label (bold, letter-spaced, text-shadow glow) more prominent — both glow in the state color (green when clean, red on issues). Status + meta unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)