### PR TITLE
docs: document the permission-union role accuracy fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ This tool requires zero manual maintenance for daily operation. Every night at *
 ├── fetch_roles.py     Calls Microsoft Graph API via OIDC token (live source of truth)
 │   ├── Graph API      graph.microsoft.com/v1.0/roleManagement/directory/roleDefinitions
 │   │                  Authenticated via OIDC token
-│   │                  → data/roles_graph_raw.json  (source of truth for IDs + permissions)
+│   │                  → data/roles_graph_raw.json  (source of truth for IDs; permissions reconciled with docs)
 │   └── Docs scrape    Also scrapes MicrosoftDocs/entra-docs for descriptions
 │                      → data/roles.json            (human-readable metadata)
 │
@@ -187,6 +187,7 @@ This tool requires zero manual maintenance for daily operation. Every night at *
 │                      Logs every change with timestamp to D1 role_changes table
 │
 ├── enrich.py          Cross-references roles_graph_raw.json vs roles.json
+│                      Permissions = union of Graph + docs (never under-states a role)
 │                      Roles in Graph API but not in docs → isShadowRole: true
 │                      Builds master.json and resolves role names to IDs
 │
@@ -223,7 +224,7 @@ entra-rolelens/
 │   ├── fetch_roles.py             # Graph API (OIDC) + docs scrape — dual source
 │   ├── scrape_tasks.py            # Scrapes task → role mappings
 │   ├── diff_roles.py              # Detects role changes
-│   ├── enrich.py                  # Shadow role detection + builds master.json
+│   ├── enrich.py                  # Union permissions + shadow detection → master.json
 │   ├── validate.py                # Quality gate
 │   ├── coverage_report.py         # Flags new roles lacking task coverage
 │   └── push_to_cloudflare.py      # Writes to KV + D1
@@ -255,7 +256,7 @@ entra-rolelens/
 | MicrosoftDocs/entra-docs | `github.com/MicrosoftDocs/entra-docs` | Role descriptions · metadata |
 | Microsoft Learn | `learn.microsoft.com/.../delegate-by-task` | Task → minimum role mappings · 211 tasks |
 
-**Why dual sources?** The Graph API is the authoritative source for role IDs and permissions but does not expose task → role mappings. The documentation scrape fills that gap. Together they enable the shadow role detector: roles that Microsoft has deployed to the API but not yet announced in documentation.
+**Why dual sources?** The Graph API is authoritative for role IDs; the documentation scrape supplies task → role mappings and human-readable metadata. The two sources also disagree on a role's **permissions** during Microsoft rollout windows — the docs lead for brand-new roles (e.g. the agent-identity permissions), the Graph API leads for some mature roles. RoleLens reconciles them with a **union per role**, so the catalog never *under-states* what a role grants — keeping role detail, diff, and least-privilege search consistent with what Microsoft has published (and with "What's new"). This dual sourcing also powers the shadow role detector: roles Microsoft has deployed to the API but not yet documented.
 
 ---
 

--- a/pipeline/enrich.py
+++ b/pipeline/enrich.py
@@ -11,7 +11,13 @@ Data sources:
 Cross-reference logic:
   - Roles in Graph API AND docs: merge, use docs isPrivileged + description
   - Roles in Graph API but NOT docs: flag isShadowRole: true
-  - Permissions: flattened from Graph API rolePermissions[].allowedResourceActions
+  - Permissions: UNION of the Graph API and docs permission sets per role. The
+    two sources each lead during Microsoft rollout windows — the docs lead for
+    brand-new roles (e.g. the agent-identity permissions), the Graph API leads
+    for some mature roles — so unioning them keeps the catalog from ever
+    *under-stating* what a role grants (the safe direction for a least-privilege
+    tool, and it keeps role detail/diff/search consistent with "What's new").
+    Shadow roles (Graph-only) use the Graph permissions as-is.
 
 Output: data/master.json with shadow_role_count field added.
 """


### PR DESCRIPTION
Documents the enrich.py permission reconciliation (PR #98): the catalog now uses the UNION of Graph API + docs permissions per role, so it never under-states what a role grants during Microsoft rollout windows. Updates the enrich.py docstring, the pipeline diagram, the 'Why dual sources?' explainer, and the project-structure note. Cosmetic Trivy strip intentionally not documented. Auto-generated README sections untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)