### PR TITLE
chore: add Cloudflare Web Analytics beacon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3024,5 +3024,6 @@ Content-Type: application/json
     setInterval(loadStatus, 60000);
   })();
 </script>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "e28c98abdc744466a3c2cd7cf7b1f79d"}'></script><!-- End Cloudflare Web Analytics -->
 </body>
 </html>


### PR DESCRIPTION
Adds the Cloudflare Web Analytics snippet before </body>. Privacy-friendly, no cookies. 🤖 Generated with [Claude Code](https://claude.com/claude-code)