### PR TITLE
feat: expand AI/agent-identity example task pills

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1572,7 +1572,7 @@
       </div>
       <div class="search-hint" id="search-hint"></div>
 
-      <!-- Example pills — 24 common Entra admin tasks -->
+      <!-- Example pills — 30 common Entra admin tasks -->
       <div class="example-pills" id="example-pills">
         <button class="pill-btn" onclick="runPillSearch('reset user MFA')">reset user MFA</button>
         <button class="pill-btn" onclick="runPillSearch('reset user password')">reset user password</button>
@@ -1593,10 +1593,16 @@
         <button class="pill-btn" onclick="runPillSearch('manage administrative units')">manage administrative units</button>
         <button class="pill-btn" onclick="runPillSearch('manage access packages')">manage access packages</button>
         <button class="pill-btn" onclick="runPillSearch('manage AI agents')">manage AI agents</button>
+        <button class="pill-btn" onclick="runPillSearch('register AI agent')">register AI agent</button>
+        <button class="pill-btn" onclick="runPillSearch('develop AI agents')">develop AI agents</button>
+        <button class="pill-btn" onclick="runPillSearch('manage agent registry')">manage agent registry</button>
+        <button class="pill-btn" onclick="runPillSearch('read agent registry')">read agent registry</button>
+        <button class="pill-btn" onclick="runPillSearch('configure AI policies')">configure AI policies</button>
+        <button class="pill-btn" onclick="runPillSearch('manage Copilot governance')">manage Copilot governance</button>
+        <button class="pill-btn" onclick="runPillSearch('view Copilot activity')">view Copilot activity</button>
+        <button class="pill-btn" onclick="runPillSearch('read AI usage')">read AI usage</button>
         <button class="pill-btn" onclick="runPillSearch('configure GDAP')">configure GDAP</button>
         <button class="pill-btn" onclick="runPillSearch('backup Entra directory')">backup Entra directory</button>
-        <button class="pill-btn" onclick="runPillSearch('manage Copilot governance')">manage Copilot governance</button>
-        <button class="pill-btn" onclick="runPillSearch('manage agent registry')">manage agent registry</button>
         <button class="pill-btn" onclick="runPillSearch('restore deleted objects')">restore deleted objects</button>
       </div>
 


### PR DESCRIPTION
## Summary
- The \`Agent Identity\` feature area in `data/tasks.json` has 10 real tasks spanning 5 distinct AI-related roles (Agent ID Administrator, Agent ID Developer, Agent Registry Administrator, AI Administrator, AI Reader), but only 3 example pills surfaced any of them — leaving Agent ID Developer and AI Reader with zero visibility on the landing page.
- Adds 6 new example pills, verified against the live search API (each resolves the intended task as the #1 result):
  - `register AI agent` → Register an AI agent identity
  - `develop AI agents` → Develop and test AI agent service principals
  - `read agent registry` → Read agent registry entries
  - `configure AI policies` → Configure AI policies and governance
  - `view Copilot activity` → View Copilot activity and permissions
  - `read AI usage` → Read AI usage and audit data
- Pill count goes from 24 → 30; all 5 AI-related roles are now represented by at least one example task.

No backend/data changes — purely front-end example chips pointing at existing, already-indexed tasks.

## Test plan
- [x] Queried `/api/search` for each new phrase against production — top result matches the intended task for all 6
- [x] Diffed against current master — only the example-pills block changed
- [ ] Visual check on Cloudflare Pages preview (pill wrapping/spacing with 30 items)