### PR TITLE
fix: brighten muted text color for readability / WCAG AA contrast

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,7 +27,7 @@
       --accent-dim:#0F5C94;
       --added:     #00E5A3;
       --text:      #E2E8F0;
-      --muted:     #64748B;
+      --muted:     #8C9AC0;
       --danger:    #F87171;
       --warn:      #FBBF24;
       --only-a:    #F87171;
@@ -189,7 +189,7 @@
       border: none;
       cursor: pointer;
       background: transparent;
-      color: #5A6A90;
+      color: #7885A8;
       transition: all 0.2s ease;
       white-space: nowrap;
       letter-spacing: 0.03em;
@@ -518,7 +518,7 @@
       white-space: pre;
       margin: 0;
     }
-    .snip-comment { color: var(--muted); font-style: italic; opacity: 0.65; }
+    .snip-comment { color: var(--muted); font-style: italic; opacity: 0.8; }
 
     .copy-btn {
       font-family: var(--font-mono);


### PR DESCRIPTION
## Summary
Secondary/body text across the site (card descriptions, task labels, What's New action text, footer, etc.) uses `--muted`, which only measured **4.2:1** contrast against the page background — under the WCAG AA threshold (4.5:1) for normal text. This is the "text looks too dark" feedback.

- `--muted`: `#64748B` → `#8C9AC0` (**4.2:1 → 7.1:1**, AAA) — used in ~50 places, covers the bulk of the fix
- `.tab-pill` inactive-tab color: `#5A6A90` → `#7885A8` (**3.7:1 → 5.5:1**, AA)
- `.snip-comment` (italic code-snippet comment) opacity: `0.65` → `0.8` — the old opacity compounded with `--muted` to an effective **3.55:1** even after the base fix; now **4.9:1**

Verified all three against every background surface tone used in the page (`--bg`, `--surface`, `--surface2`) — comfortably passes AA everywhere.

No layout, markup, or other color changes.

## Test plan
- [x] Computed WCAG contrast ratios for old/new values against all 3 surface backgrounds
- [ ] Visual check on Cloudflare Pages preview