### PR TITLE
feat: animated WebGL magnifying-glass background

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -53,7 +53,7 @@
       flex-direction: column;
     }
 
-    /* Dot-grid background */
+    /* Dot-grid background — fallback for no-WebGL / prefers-reduced-motion */
     body::before {
       content: '';
       position: fixed;
@@ -63,6 +63,17 @@
       opacity: 0.45;
       pointer-events: none;
       z-index: 0;
+    }
+    /* Node-graph canvas takes over from the dot-grid once it boots successfully */
+    body.has-bg-canvas::before { display: none; }
+    #bg-graph {
+      position: fixed;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 0;
+      pointer-events: none;
+      display: block;
     }
 
     /* ── Layout ─────────────────────────────────────────────────────── */
@@ -1449,6 +1460,8 @@
 </head>
 <body>
 
+<canvas id="bg-graph" aria-hidden="true"></canvas>
+
 <!-- ── Header ──────────────────────────────────────────────────────── -->
 <header>
   <div class="container">
@@ -1736,6 +1749,264 @@
   let allRoles = [];         // [{id, display_name, is_privileged}]
   let selectedRoleA = null;  // display_name string
   let selectedRoleB = null;
+
+  // ── Background node-graph (decorative WebGL) ───────────────────────────
+  // Drifting dots (roles/permissions/tasks) linked when close, with the
+  // occasional pulse traveling an edge — a nod to the RBAC graph this app
+  // is exploring. Fails silently (leaves the CSS dot-grid in place) if
+  // WebGL is unavailable or the visitor prefers reduced motion.
+  function initBgGraph() {
+    try {
+      if (!window.matchMedia('(prefers-reduced-motion: no-preference)').matches) return;
+      const canvas = document.getElementById('bg-graph');
+      if (!canvas) return;
+      const glOpts = { alpha: true, antialias: true, premultipliedAlpha: false };
+      const gl = canvas.getContext('webgl', glOpts) || canvas.getContext('experimental-webgl', glOpts);
+      if (!gl) return;
+
+      function compileShader(type, src) {
+        const s = gl.createShader(type);
+        gl.shaderSource(s, src);
+        gl.compileShader(s);
+        if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+          gl.deleteShader(s);
+          return null;
+        }
+        return s;
+      }
+      function makeProgram(vsSrc, fsSrc) {
+        const vs = compileShader(gl.VERTEX_SHADER, vsSrc);
+        const fs = compileShader(gl.FRAGMENT_SHADER, fsSrc);
+        if (!vs || !fs) return null;
+        const p = gl.createProgram();
+        gl.attachShader(p, vs);
+        gl.attachShader(p, fs);
+        gl.linkProgram(p);
+        if (!gl.getProgramParameter(p, gl.LINK_STATUS)) return null;
+        return p;
+      }
+
+      const VS = `
+        attribute vec2 aPosition;
+        attribute float aAlpha;
+        attribute float aSize;
+        uniform vec2 uResolution;
+        varying float vAlpha;
+        void main() {
+          vec2 clip = (aPosition / uResolution) * 2.0 - 1.0;
+          clip.y = -clip.y;
+          gl_Position = vec4(clip, 0.0, 1.0);
+          gl_PointSize = aSize;
+          vAlpha = aAlpha;
+        }
+      `;
+      const FS_LINE = `
+        precision mediump float;
+        varying float vAlpha;
+        uniform vec3 uColor;
+        void main() { gl_FragColor = vec4(uColor, vAlpha); }
+      `;
+      const FS_POINT = `
+        precision mediump float;
+        varying float vAlpha;
+        uniform vec3 uColor;
+        void main() {
+          float d = length(gl_PointCoord - vec2(0.5));
+          float a = smoothstep(0.5, 0.0, d) * vAlpha;
+          gl_FragColor = vec4(uColor, a);
+        }
+      `;
+
+      const lineProg = makeProgram(VS, FS_LINE);
+      const pointProg = makeProgram(VS, FS_POINT);
+      if (!lineProg || !pointProg) return;
+
+      function locs(p) {
+        return {
+          program: p,
+          aPosition: gl.getAttribLocation(p, 'aPosition'),
+          aAlpha: gl.getAttribLocation(p, 'aAlpha'),
+          aSize: gl.getAttribLocation(p, 'aSize'),
+          uResolution: gl.getUniformLocation(p, 'uResolution'),
+          uColor: gl.getUniformLocation(p, 'uColor'),
+        };
+      }
+      const L = locs(lineProg);
+      const P = locs(pointProg);
+
+      const posBuf = gl.createBuffer();
+      const alphaBuf = gl.createBuffer();
+      const sizeBuf = gl.createBuffer();
+
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const MAX_DIST = 170;
+      const ACCENT = [47 / 255, 158 / 255, 245 / 255];
+      const PULSE_COLOR = [0.75, 0.9, 1.0];
+
+      let width = 0, height = 0, nodes = [], pulses = [], lastPulseAt = 0, rafId = null;
+
+      function initNodes() {
+        const count = Math.max(24, Math.min(70, Math.floor((width * height) / 16000)));
+        nodes = new Array(count).fill(0).map(() => ({
+          x: Math.random() * width,
+          y: Math.random() * height,
+          vx: (Math.random() - 0.5) * 14,
+          vy: (Math.random() - 0.5) * 14,
+          size: 2 + Math.random() * 2.5,
+        }));
+      }
+
+      function resize() {
+        width = window.innerWidth;
+        height = window.innerHeight;
+        canvas.width = Math.floor(width * dpr);
+        canvas.height = Math.floor(height * dpr);
+        gl.viewport(0, 0, canvas.width, canvas.height);
+        initNodes();
+      }
+
+      function spawnPulse(edges, now) {
+        if (!edges.length) return;
+        const e = edges[Math.floor(Math.random() * edges.length)];
+        pulses.push({ a: e.a, b: e.b, start: now, dur: 900 + Math.random() * 700 });
+      }
+
+      let lastT = performance.now();
+
+      function frame(now) {
+        const dt = Math.min(now - lastT, 50) / 1000;
+        lastT = now;
+
+        for (const n of nodes) {
+          n.x += n.vx * dt;
+          n.y += n.vy * dt;
+          if (n.x < -20) n.x = width + 20;
+          if (n.x > width + 20) n.x = -20;
+          if (n.y < -20) n.y = height + 20;
+          if (n.y > height + 20) n.y = -20;
+        }
+
+        const edges = [];
+        for (let i = 0; i < nodes.length; i++) {
+          for (let j = i + 1; j < nodes.length; j++) {
+            const dx = nodes[i].x - nodes[j].x, dy = nodes[i].y - nodes[j].y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            if (dist < MAX_DIST) edges.push({ a: i, b: j, dist });
+          }
+        }
+
+        if (now - lastPulseAt > 1400 + Math.random() * 1400) {
+          spawnPulse(edges, now);
+          lastPulseAt = now;
+        }
+        pulses = pulses.filter(p => now - p.start < p.dur);
+
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.enable(gl.BLEND);
+        gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+
+        // edges
+        const linePos = new Float32Array(edges.length * 4);
+        const lineAlpha = new Float32Array(edges.length * 2);
+        edges.forEach((e, i) => {
+          const na = nodes[e.a], nb = nodes[e.b];
+          const a = (1 - e.dist / MAX_DIST) * 0.22;
+          linePos[i * 4] = na.x * dpr; linePos[i * 4 + 1] = na.y * dpr;
+          linePos[i * 4 + 2] = nb.x * dpr; linePos[i * 4 + 3] = nb.y * dpr;
+          lineAlpha[i * 2] = a; lineAlpha[i * 2 + 1] = a;
+        });
+        gl.useProgram(L.program);
+        gl.uniform2f(L.uResolution, canvas.width, canvas.height);
+        gl.uniform3fv(L.uColor, ACCENT);
+        gl.bindBuffer(gl.ARRAY_BUFFER, posBuf);
+        gl.bufferData(gl.ARRAY_BUFFER, linePos, gl.DYNAMIC_DRAW);
+        gl.enableVertexAttribArray(L.aPosition);
+        gl.vertexAttribPointer(L.aPosition, 2, gl.FLOAT, false, 0, 0);
+        gl.bindBuffer(gl.ARRAY_BUFFER, alphaBuf);
+        gl.bufferData(gl.ARRAY_BUFFER, lineAlpha, gl.DYNAMIC_DRAW);
+        gl.enableVertexAttribArray(L.aAlpha);
+        gl.vertexAttribPointer(L.aAlpha, 1, gl.FLOAT, false, 0, 0);
+        if (L.aSize >= 0) gl.disableVertexAttribArray(L.aSize);
+        if (edges.length) gl.drawArrays(gl.LINES, 0, edges.length * 2);
+
+        // nodes
+        const nodePos = new Float32Array(nodes.length * 2);
+        const nodeAlpha = new Float32Array(nodes.length);
+        const nodeSize = new Float32Array(nodes.length);
+        nodes.forEach((n, i) => {
+          nodePos[i * 2] = n.x * dpr; nodePos[i * 2 + 1] = n.y * dpr;
+          nodeAlpha[i] = 0.55;
+          nodeSize[i] = n.size * dpr;
+        });
+        gl.useProgram(P.program);
+        gl.uniform2f(P.uResolution, canvas.width, canvas.height);
+        gl.uniform3fv(P.uColor, ACCENT);
+        gl.bindBuffer(gl.ARRAY_BUFFER, posBuf);
+        gl.bufferData(gl.ARRAY_BUFFER, nodePos, gl.DYNAMIC_DRAW);
+        gl.enableVertexAttribArray(P.aPosition);
+        gl.vertexAttribPointer(P.aPosition, 2, gl.FLOAT, false, 0, 0);
+        gl.bindBuffer(gl.ARRAY_BUFFER, alphaBuf);
+        gl.bufferData(gl.ARRAY_BUFFER, nodeAlpha, gl.DYNAMIC_DRAW);
+        gl.enableVertexAttribArray(P.aAlpha);
+        gl.vertexAttribPointer(P.aAlpha, 1, gl.FLOAT, false, 0, 0);
+        gl.bindBuffer(gl.ARRAY_BUFFER, sizeBuf);
+        gl.bufferData(gl.ARRAY_BUFFER, nodeSize, gl.DYNAMIC_DRAW);
+        gl.enableVertexAttribArray(P.aSize);
+        gl.vertexAttribPointer(P.aSize, 1, gl.FLOAT, false, 0, 0);
+        gl.drawArrays(gl.POINTS, 0, nodes.length);
+
+        // pulses (traveling highlights along an edge — permission being granted)
+        if (pulses.length) {
+          const pPos = new Float32Array(pulses.length * 2);
+          const pAlpha = new Float32Array(pulses.length);
+          const pSize = new Float32Array(pulses.length);
+          pulses.forEach((p, i) => {
+            const t = (now - p.start) / p.dur;
+            const na = nodes[p.a], nb = nodes[p.b];
+            pPos[i * 2] = (na.x + (nb.x - na.x) * t) * dpr;
+            pPos[i * 2 + 1] = (na.y + (nb.y - na.y) * t) * dpr;
+            pAlpha[i] = Math.sin(Math.min(t, 1) * Math.PI) * 0.9;
+            pSize[i] = 5 * dpr;
+          });
+          gl.uniform3fv(P.uColor, PULSE_COLOR);
+          gl.bindBuffer(gl.ARRAY_BUFFER, posBuf);
+          gl.bufferData(gl.ARRAY_BUFFER, pPos, gl.DYNAMIC_DRAW);
+          gl.vertexAttribPointer(P.aPosition, 2, gl.FLOAT, false, 0, 0);
+          gl.bindBuffer(gl.ARRAY_BUFFER, alphaBuf);
+          gl.bufferData(gl.ARRAY_BUFFER, pAlpha, gl.DYNAMIC_DRAW);
+          gl.vertexAttribPointer(P.aAlpha, 1, gl.FLOAT, false, 0, 0);
+          gl.bindBuffer(gl.ARRAY_BUFFER, sizeBuf);
+          gl.bufferData(gl.ARRAY_BUFFER, pSize, gl.DYNAMIC_DRAW);
+          gl.vertexAttribPointer(P.aSize, 1, gl.FLOAT, false, 0, 0);
+          gl.drawArrays(gl.POINTS, 0, pulses.length);
+        }
+
+        rafId = requestAnimationFrame(frame);
+      }
+
+      let resizeTimer = null;
+      window.addEventListener('resize', () => {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(resize, 150);
+      });
+      document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+          if (rafId) cancelAnimationFrame(rafId);
+          rafId = null;
+        } else if (!rafId) {
+          lastT = performance.now();
+          rafId = requestAnimationFrame(frame);
+        }
+      });
+
+      gl.clearColor(0, 0, 0, 0);
+      resize();
+      document.body.classList.add('has-bg-canvas');
+      rafId = requestAnimationFrame(frame);
+    } catch (err) {
+      console.warn('bg-graph disabled:', err);
+    }
+  }
 
   // ── Mode toggle ──────────────────────────────────────────────────────
   function switchMode(mode) {
@@ -3026,6 +3297,7 @@ Content-Type: application/json
   }
 
   // ── Boot ─────────────────────────────────────────────────────────────
+  initBgGraph();
   (async () => {
     await Promise.all([loadStatus(), loadRoles(), loadGitHubStats(), loadWhatsNew()]);
     setInterval(loadStatus, 60000);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1839,7 +1839,7 @@
       const sizeBuf = gl.createBuffer();
 
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
-      const MAX_DIST = 170;
+      const MAX_DIST = 230;
       const ACCENT = [47 / 255, 158 / 255, 245 / 255];
       const PULSE_COLOR = [0.75, 0.9, 1.0];
 
@@ -1852,7 +1852,7 @@
           y: Math.random() * height,
           vx: (Math.random() - 0.5) * 14,
           vy: (Math.random() - 0.5) * 14,
-          size: 2 + Math.random() * 2.5,
+          size: 3.5 + Math.random() * 3.5,
         }));
       }
 
@@ -1910,7 +1910,7 @@
         const lineAlpha = new Float32Array(edges.length * 2);
         edges.forEach((e, i) => {
           const na = nodes[e.a], nb = nodes[e.b];
-          const a = (1 - e.dist / MAX_DIST) * 0.22;
+          const a = (1 - e.dist / MAX_DIST) * 0.5;
           linePos[i * 4] = na.x * dpr; linePos[i * 4 + 1] = na.y * dpr;
           linePos[i * 4 + 2] = nb.x * dpr; linePos[i * 4 + 3] = nb.y * dpr;
           lineAlpha[i * 2] = a; lineAlpha[i * 2 + 1] = a;
@@ -1933,10 +1933,14 @@
         const nodePos = new Float32Array(nodes.length * 2);
         const nodeAlpha = new Float32Array(nodes.length);
         const nodeSize = new Float32Array(nodes.length);
+        const haloAlpha = new Float32Array(nodes.length);
+        const haloSize = new Float32Array(nodes.length);
         nodes.forEach((n, i) => {
           nodePos[i * 2] = n.x * dpr; nodePos[i * 2 + 1] = n.y * dpr;
-          nodeAlpha[i] = 0.55;
+          nodeAlpha[i] = 0.95;
           nodeSize[i] = n.size * dpr;
+          haloAlpha[i] = 0.28;
+          haloSize[i] = n.size * dpr * 4.5;
         });
         gl.useProgram(P.program);
         gl.uniform2f(P.uResolution, canvas.width, canvas.height);
@@ -1945,13 +1949,24 @@
         gl.bufferData(gl.ARRAY_BUFFER, nodePos, gl.DYNAMIC_DRAW);
         gl.enableVertexAttribArray(P.aPosition);
         gl.vertexAttribPointer(P.aPosition, 2, gl.FLOAT, false, 0, 0);
+
+        // soft halo pass (larger, dimmer) underneath the core dot for glow
         gl.bindBuffer(gl.ARRAY_BUFFER, alphaBuf);
-        gl.bufferData(gl.ARRAY_BUFFER, nodeAlpha, gl.DYNAMIC_DRAW);
+        gl.bufferData(gl.ARRAY_BUFFER, haloAlpha, gl.DYNAMIC_DRAW);
         gl.enableVertexAttribArray(P.aAlpha);
         gl.vertexAttribPointer(P.aAlpha, 1, gl.FLOAT, false, 0, 0);
         gl.bindBuffer(gl.ARRAY_BUFFER, sizeBuf);
-        gl.bufferData(gl.ARRAY_BUFFER, nodeSize, gl.DYNAMIC_DRAW);
+        gl.bufferData(gl.ARRAY_BUFFER, haloSize, gl.DYNAMIC_DRAW);
         gl.enableVertexAttribArray(P.aSize);
+        gl.vertexAttribPointer(P.aSize, 1, gl.FLOAT, false, 0, 0);
+        gl.drawArrays(gl.POINTS, 0, nodes.length);
+
+        // core dot pass
+        gl.bindBuffer(gl.ARRAY_BUFFER, alphaBuf);
+        gl.bufferData(gl.ARRAY_BUFFER, nodeAlpha, gl.DYNAMIC_DRAW);
+        gl.vertexAttribPointer(P.aAlpha, 1, gl.FLOAT, false, 0, 0);
+        gl.bindBuffer(gl.ARRAY_BUFFER, sizeBuf);
+        gl.bufferData(gl.ARRAY_BUFFER, nodeSize, gl.DYNAMIC_DRAW);
         gl.vertexAttribPointer(P.aSize, 1, gl.FLOAT, false, 0, 0);
         gl.drawArrays(gl.POINTS, 0, nodes.length);
 
@@ -1966,7 +1981,7 @@
             pPos[i * 2] = (na.x + (nb.x - na.x) * t) * dpr;
             pPos[i * 2 + 1] = (na.y + (nb.y - na.y) * t) * dpr;
             pAlpha[i] = Math.sin(Math.min(t, 1) * Math.PI) * 0.9;
-            pSize[i] = 5 * dpr;
+            pSize[i] = 8 * dpr;
           });
           gl.uniform3fv(P.uColor, PULSE_COLOR);
           gl.bindBuffer(gl.ARRAY_BUFFER, posBuf);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1750,17 +1750,20 @@
   let selectedRoleA = null;  // display_name string
   let selectedRoleB = null;
 
-  // ── Background node-graph (decorative WebGL) ───────────────────────────
-  // Drifting dots (roles/permissions/tasks) linked when close, with the
-  // occasional pulse traveling an edge — a nod to the RBAC graph this app
-  // is exploring. Fails silently (leaves the CSS dot-grid in place) if
-  // WebGL is unavailable or the visitor prefers reduced motion.
+  // ── Background magnifying-glass sweep (decorative WebGL) ───────────────
+  // A single glowing magnifying-glass silhouette drifts slowly across the
+  // page on a lazy Lissajous path; a faint procedural dot texture sits
+  // underneath and "magnifies" (denser/brighter) inside the lens — a nod to
+  // this app's core action (search icon in the header). One full-screen
+  // shader, one draw call per frame. Fails silently (leaves the CSS
+  // dot-grid in place) if WebGL is unavailable or the visitor prefers
+  // reduced motion.
   function initBgGraph() {
     try {
       if (!window.matchMedia('(prefers-reduced-motion: no-preference)').matches) return;
       const canvas = document.getElementById('bg-graph');
       if (!canvas) return;
-      const glOpts = { alpha: true, antialias: true, premultipliedAlpha: false };
+      const glOpts = { alpha: true, antialias: true, premultipliedAlpha: true };
       const gl = canvas.getContext('webgl', glOpts) || canvas.getContext('experimental-webgl', glOpts);
       if (!gl) return;
 
@@ -1769,6 +1772,7 @@
         gl.shaderSource(s, src);
         gl.compileShader(s);
         if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+          console.warn('bg-graph shader error:', gl.getShaderInfoLog(s));
           gl.deleteShader(s);
           return null;
         }
@@ -1782,79 +1786,91 @@
         gl.attachShader(p, vs);
         gl.attachShader(p, fs);
         gl.linkProgram(p);
-        if (!gl.getProgramParameter(p, gl.LINK_STATUS)) return null;
+        if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+          console.warn('bg-graph link error:', gl.getProgramInfoLog(p));
+          return null;
+        }
         return p;
       }
 
       const VS = `
-        attribute vec2 aPosition;
-        attribute float aAlpha;
-        attribute float aSize;
+        attribute vec2 aPos;
+        varying vec2 vUv;
+        void main() {
+          vUv = aPos * 0.5 + 0.5;
+          gl_Position = vec4(aPos, 0.0, 1.0);
+        }
+      `;
+      const FS = `
+        precision mediump float;
+        varying vec2 vUv;
         uniform vec2 uResolution;
-        varying float vAlpha;
+        uniform vec2 uLensCenter;
+        uniform float uLensRadius;
+        uniform vec2 uHandleP1;
+        uniform vec2 uHandleP2;
+        uniform float uBreath;
+        uniform vec3 uColor;
+
+        float sdSegment(vec2 p, vec2 a, vec2 b) {
+          vec2 pa = p - a, ba = b - a;
+          float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+          return length(pa - ba * h);
+        }
+
+        float dotGrid(vec2 p, float spacing, float dotRadius) {
+          vec2 cell = mod(p, spacing) - spacing * 0.5;
+          float d = length(cell);
+          return 1.0 - smoothstep(dotRadius - 1.0, dotRadius + 1.0, d);
+        }
+
         void main() {
-          vec2 clip = (aPosition / uResolution) * 2.0 - 1.0;
-          clip.y = -clip.y;
-          gl_Position = vec4(clip, 0.0, 1.0);
-          gl_PointSize = aSize;
-          vAlpha = aAlpha;
+          vec2 fragPx = vec2(vUv.x, 1.0 - vUv.y) * uResolution;
+          float distToLens = length(fragPx - uLensCenter);
+
+          float zoom = distToLens < uLensRadius ? 1.6 : 1.0;
+          vec2 sampleP = uLensCenter + (fragPx - uLensCenter) / zoom;
+          float grid = dotGrid(sampleP, 30.0, 1.6);
+
+          float insideLens = 1.0 - smoothstep(uLensRadius - 12.0, uLensRadius, distToLens);
+          float gridAlpha = grid * 0.12 + grid * insideLens * 0.32;
+
+          float ringDist = abs(distToLens - uLensRadius);
+          float ring = smoothstep(2.5, 0.0, ringDist) * (0.75 + uBreath * 0.25);
+          float ringGlow = smoothstep(20.0, 0.0, ringDist) * 0.16;
+
+          float hd = sdSegment(fragPx, uHandleP1, uHandleP2);
+          float handle = smoothstep(3.0, 0.0, hd);
+          float handleGlow = smoothstep(14.0, 0.0, hd) * 0.14;
+
+          float lensFill = (1.0 - smoothstep(uLensRadius - 1.5, uLensRadius, distToLens)) * 0.04;
+
+          float alpha = clamp(gridAlpha + ring + ringGlow + handle + handleGlow + lensFill, 0.0, 1.0);
+          gl_FragColor = vec4(uColor * alpha, alpha);
         }
       `;
-      const FS_LINE = `
-        precision mediump float;
-        varying float vAlpha;
-        uniform vec3 uColor;
-        void main() { gl_FragColor = vec4(uColor, vAlpha); }
-      `;
-      const FS_POINT = `
-        precision mediump float;
-        varying float vAlpha;
-        uniform vec3 uColor;
-        void main() {
-          float d = length(gl_PointCoord - vec2(0.5));
-          float a = smoothstep(0.5, 0.0, d) * vAlpha;
-          gl_FragColor = vec4(uColor, a);
-        }
-      `;
 
-      const lineProg = makeProgram(VS, FS_LINE);
-      const pointProg = makeProgram(VS, FS_POINT);
-      if (!lineProg || !pointProg) return;
+      const prog = makeProgram(VS, FS);
+      if (!prog) return;
 
-      function locs(p) {
-        return {
-          program: p,
-          aPosition: gl.getAttribLocation(p, 'aPosition'),
-          aAlpha: gl.getAttribLocation(p, 'aAlpha'),
-          aSize: gl.getAttribLocation(p, 'aSize'),
-          uResolution: gl.getUniformLocation(p, 'uResolution'),
-          uColor: gl.getUniformLocation(p, 'uColor'),
-        };
-      }
-      const L = locs(lineProg);
-      const P = locs(pointProg);
+      const aPos = gl.getAttribLocation(prog, 'aPos');
+      const uResolution = gl.getUniformLocation(prog, 'uResolution');
+      const uLensCenter = gl.getUniformLocation(prog, 'uLensCenter');
+      const uLensRadius = gl.getUniformLocation(prog, 'uLensRadius');
+      const uHandleP1 = gl.getUniformLocation(prog, 'uHandleP1');
+      const uHandleP2 = gl.getUniformLocation(prog, 'uHandleP2');
+      const uBreath = gl.getUniformLocation(prog, 'uBreath');
+      const uColor = gl.getUniformLocation(prog, 'uColor');
 
-      const posBuf = gl.createBuffer();
-      const alphaBuf = gl.createBuffer();
-      const sizeBuf = gl.createBuffer();
+      const quadBuf = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, quadBuf);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]), gl.STATIC_DRAW);
 
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
-      const MAX_DIST = 230;
       const ACCENT = [47 / 255, 158 / 255, 245 / 255];
-      const PULSE_COLOR = [0.75, 0.9, 1.0];
+      const HANDLE_ANGLE = Math.PI / 4; // matches the search-icon handle orientation
 
-      let width = 0, height = 0, nodes = [], pulses = [], lastPulseAt = 0, rafId = null;
-
-      function initNodes() {
-        const count = Math.max(24, Math.min(70, Math.floor((width * height) / 16000)));
-        nodes = new Array(count).fill(0).map(() => ({
-          x: Math.random() * width,
-          y: Math.random() * height,
-          vx: (Math.random() - 0.5) * 14,
-          vy: (Math.random() - 0.5) * 14,
-          size: 3.5 + Math.random() * 3.5,
-        }));
-      }
+      let width = 0, height = 0, lensRadius = 100, rafId = null;
 
       function resize() {
         width = window.innerWidth;
@@ -1862,139 +1878,39 @@
         canvas.width = Math.floor(width * dpr);
         canvas.height = Math.floor(height * dpr);
         gl.viewport(0, 0, canvas.width, canvas.height);
-        initNodes();
+        lensRadius = Math.max(70, Math.min(140, width * 0.09)) * dpr;
       }
-
-      function spawnPulse(edges, now) {
-        if (!edges.length) return;
-        const e = edges[Math.floor(Math.random() * edges.length)];
-        pulses.push({ a: e.a, b: e.b, start: now, dur: 900 + Math.random() * 700 });
-      }
-
-      let lastT = performance.now();
 
       function frame(now) {
-        const dt = Math.min(now - lastT, 50) / 1000;
-        lastT = now;
+        const t = now / 1000;
+        const marginX = lensRadius + lensRadius * 0.9;
+        const marginY = marginX;
+        const cx = canvas.width / 2 + Math.sin(t * 0.07) * Math.max(0, canvas.width / 2 - marginX);
+        const cy = canvas.height / 2 + Math.sin(t * 0.05 + 1.3) * Math.max(0, canvas.height / 2 - marginY);
 
-        for (const n of nodes) {
-          n.x += n.vx * dt;
-          n.y += n.vy * dt;
-          if (n.x < -20) n.x = width + 20;
-          if (n.x > width + 20) n.x = -20;
-          if (n.y < -20) n.y = height + 20;
-          if (n.y > height + 20) n.y = -20;
-        }
-
-        const edges = [];
-        for (let i = 0; i < nodes.length; i++) {
-          for (let j = i + 1; j < nodes.length; j++) {
-            const dx = nodes[i].x - nodes[j].x, dy = nodes[i].y - nodes[j].y;
-            const dist = Math.sqrt(dx * dx + dy * dy);
-            if (dist < MAX_DIST) edges.push({ a: i, b: j, dist });
-          }
-        }
-
-        if (now - lastPulseAt > 1400 + Math.random() * 1400) {
-          spawnPulse(edges, now);
-          lastPulseAt = now;
-        }
-        pulses = pulses.filter(p => now - p.start < p.dur);
+        const hx1 = cx + Math.cos(HANDLE_ANGLE) * lensRadius;
+        const hy1 = cy + Math.sin(HANDLE_ANGLE) * lensRadius;
+        const handleLen = lensRadius * 0.65;
+        const hx2 = hx1 + Math.cos(HANDLE_ANGLE) * handleLen;
+        const hy2 = hy1 + Math.sin(HANDLE_ANGLE) * handleLen;
 
         gl.clear(gl.COLOR_BUFFER_BIT);
-        gl.enable(gl.BLEND);
-        gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+        gl.disable(gl.BLEND);
 
-        // edges
-        const linePos = new Float32Array(edges.length * 4);
-        const lineAlpha = new Float32Array(edges.length * 2);
-        edges.forEach((e, i) => {
-          const na = nodes[e.a], nb = nodes[e.b];
-          const a = (1 - e.dist / MAX_DIST) * 0.5;
-          linePos[i * 4] = na.x * dpr; linePos[i * 4 + 1] = na.y * dpr;
-          linePos[i * 4 + 2] = nb.x * dpr; linePos[i * 4 + 3] = nb.y * dpr;
-          lineAlpha[i * 2] = a; lineAlpha[i * 2 + 1] = a;
-        });
-        gl.useProgram(L.program);
-        gl.uniform2f(L.uResolution, canvas.width, canvas.height);
-        gl.uniform3fv(L.uColor, ACCENT);
-        gl.bindBuffer(gl.ARRAY_BUFFER, posBuf);
-        gl.bufferData(gl.ARRAY_BUFFER, linePos, gl.DYNAMIC_DRAW);
-        gl.enableVertexAttribArray(L.aPosition);
-        gl.vertexAttribPointer(L.aPosition, 2, gl.FLOAT, false, 0, 0);
-        gl.bindBuffer(gl.ARRAY_BUFFER, alphaBuf);
-        gl.bufferData(gl.ARRAY_BUFFER, lineAlpha, gl.DYNAMIC_DRAW);
-        gl.enableVertexAttribArray(L.aAlpha);
-        gl.vertexAttribPointer(L.aAlpha, 1, gl.FLOAT, false, 0, 0);
-        if (L.aSize >= 0) gl.disableVertexAttribArray(L.aSize);
-        if (edges.length) gl.drawArrays(gl.LINES, 0, edges.length * 2);
+        gl.useProgram(prog);
+        gl.bindBuffer(gl.ARRAY_BUFFER, quadBuf);
+        gl.enableVertexAttribArray(aPos);
+        gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
 
-        // nodes
-        const nodePos = new Float32Array(nodes.length * 2);
-        const nodeAlpha = new Float32Array(nodes.length);
-        const nodeSize = new Float32Array(nodes.length);
-        const haloAlpha = new Float32Array(nodes.length);
-        const haloSize = new Float32Array(nodes.length);
-        nodes.forEach((n, i) => {
-          nodePos[i * 2] = n.x * dpr; nodePos[i * 2 + 1] = n.y * dpr;
-          nodeAlpha[i] = 0.95;
-          nodeSize[i] = n.size * dpr;
-          haloAlpha[i] = 0.28;
-          haloSize[i] = n.size * dpr * 4.5;
-        });
-        gl.useProgram(P.program);
-        gl.uniform2f(P.uResolution, canvas.width, canvas.height);
-        gl.uniform3fv(P.uColor, ACCENT);
-        gl.bindBuffer(gl.ARRAY_BUFFER, posBuf);
-        gl.bufferData(gl.ARRAY_BUFFER, nodePos, gl.DYNAMIC_DRAW);
-        gl.enableVertexAttribArray(P.aPosition);
-        gl.vertexAttribPointer(P.aPosition, 2, gl.FLOAT, false, 0, 0);
+        gl.uniform2f(uResolution, canvas.width, canvas.height);
+        gl.uniform2f(uLensCenter, cx, cy);
+        gl.uniform1f(uLensRadius, lensRadius);
+        gl.uniform2f(uHandleP1, hx1, hy1);
+        gl.uniform2f(uHandleP2, hx2, hy2);
+        gl.uniform1f(uBreath, (Math.sin(t * 1.6) + 1.0) / 2.0);
+        gl.uniform3fv(uColor, ACCENT);
 
-        // soft halo pass (larger, dimmer) underneath the core dot for glow
-        gl.bindBuffer(gl.ARRAY_BUFFER, alphaBuf);
-        gl.bufferData(gl.ARRAY_BUFFER, haloAlpha, gl.DYNAMIC_DRAW);
-        gl.enableVertexAttribArray(P.aAlpha);
-        gl.vertexAttribPointer(P.aAlpha, 1, gl.FLOAT, false, 0, 0);
-        gl.bindBuffer(gl.ARRAY_BUFFER, sizeBuf);
-        gl.bufferData(gl.ARRAY_BUFFER, haloSize, gl.DYNAMIC_DRAW);
-        gl.enableVertexAttribArray(P.aSize);
-        gl.vertexAttribPointer(P.aSize, 1, gl.FLOAT, false, 0, 0);
-        gl.drawArrays(gl.POINTS, 0, nodes.length);
-
-        // core dot pass
-        gl.bindBuffer(gl.ARRAY_BUFFER, alphaBuf);
-        gl.bufferData(gl.ARRAY_BUFFER, nodeAlpha, gl.DYNAMIC_DRAW);
-        gl.vertexAttribPointer(P.aAlpha, 1, gl.FLOAT, false, 0, 0);
-        gl.bindBuffer(gl.ARRAY_BUFFER, sizeBuf);
-        gl.bufferData(gl.ARRAY_BUFFER, nodeSize, gl.DYNAMIC_DRAW);
-        gl.vertexAttribPointer(P.aSize, 1, gl.FLOAT, false, 0, 0);
-        gl.drawArrays(gl.POINTS, 0, nodes.length);
-
-        // pulses (traveling highlights along an edge — permission being granted)
-        if (pulses.length) {
-          const pPos = new Float32Array(pulses.length * 2);
-          const pAlpha = new Float32Array(pulses.length);
-          const pSize = new Float32Array(pulses.length);
-          pulses.forEach((p, i) => {
-            const t = (now - p.start) / p.dur;
-            const na = nodes[p.a], nb = nodes[p.b];
-            pPos[i * 2] = (na.x + (nb.x - na.x) * t) * dpr;
-            pPos[i * 2 + 1] = (na.y + (nb.y - na.y) * t) * dpr;
-            pAlpha[i] = Math.sin(Math.min(t, 1) * Math.PI) * 0.9;
-            pSize[i] = 8 * dpr;
-          });
-          gl.uniform3fv(P.uColor, PULSE_COLOR);
-          gl.bindBuffer(gl.ARRAY_BUFFER, posBuf);
-          gl.bufferData(gl.ARRAY_BUFFER, pPos, gl.DYNAMIC_DRAW);
-          gl.vertexAttribPointer(P.aPosition, 2, gl.FLOAT, false, 0, 0);
-          gl.bindBuffer(gl.ARRAY_BUFFER, alphaBuf);
-          gl.bufferData(gl.ARRAY_BUFFER, pAlpha, gl.DYNAMIC_DRAW);
-          gl.vertexAttribPointer(P.aAlpha, 1, gl.FLOAT, false, 0, 0);
-          gl.bindBuffer(gl.ARRAY_BUFFER, sizeBuf);
-          gl.bufferData(gl.ARRAY_BUFFER, pSize, gl.DYNAMIC_DRAW);
-          gl.vertexAttribPointer(P.aSize, 1, gl.FLOAT, false, 0, 0);
-          gl.drawArrays(gl.POINTS, 0, pulses.length);
-        }
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
 
         rafId = requestAnimationFrame(frame);
       }
@@ -2009,7 +1925,6 @@
           if (rafId) cancelAnimationFrame(rafId);
           rafId = null;
         } else if (!rafId) {
-          lastT = performance.now();
           rafId = requestAnimationFrame(frame);
         }
       });


### PR DESCRIPTION
## Summary
Complete redesign from the original approach based on feedback that the particle-dot version read as "dead pixels." Now a single, calm, thematic shape:

- One glowing magnifying-glass silhouette (ring + handle) drifts slowly across the page on a lazy Lissajous path — directly evokes the app's core action (same shape as the search icon in the header)
- A faint procedural dot texture sits underneath; inside the lens, it's rendered denser/brighter, so the lens visibly "magnifies" the texture as it passes over it
- One full-screen shader, one draw call per frame — simpler and cheaper than the earlier per-node particle approach it replaces
- Same safety properties as before: gated on `prefers-reduced-motion: no-preference` + WebGL support, fails silently back to the CSS dot-grid, pauses on tab-hidden, debounced resize

**Bug found and fixed along the way**: the first version of this shader used `gl.blendFunc(SRC_ALPHA, ONE_MINUS_SRC_ALPHA)` for a single full-screen draw onto a freshly-cleared transparent canvas. That blend equation also applies to the alpha channel itself, so a fragment's output alpha becomes `srcAlpha²` when blending against a fully-transparent destination — a dot meant to render at 12% opacity actually composited onto the page at ~0.14% opacity, invisible. Fixed by writing premultiplied color directly (`vec4(color * alpha, alpha)`) with blending disabled, since there's nothing else in the framebuffer to blend against in a single-draw-per-frame setup.

## How this was verified
I don't have a browser in my normal environment, so for this iteration I installed headless Chromium (Playwright) specifically to self-test before pushing:
- Confirmed `document.body.classList.contains('has-bg-canvas')` (successful WebGL init) on the actual deployed preview
- Found the visibility bug by zooming into a screenshot and seeing nothing render outside the lens; isolated the shader in a standalone test page to debug independent of the rest of the site's DOM
- Diffed two screenshots 3-4s apart to confirm real motion, not a frozen frame
- Visually confirmed the fixed version on both an isolated test page and the full local page with real content

## Test plan
- [x] `node --check` on extracted script — syntax valid
- [x] Self-verified rendering + motion with headless Chromium (see above)
- [ ] Final human visual check on the Cloudflare Pages preview
