### PR TITLE
ci: auto-patch worker's vulnerable transitive deps

### DIFF
--- a/.github/workflows/auto-patch-deps.yml
+++ b/.github/workflows/auto-patch-deps.yml
@@ -1,0 +1,101 @@
+name: Auto-patch worker deps
+
+# Fixes security advisories on the worker's TRANSITIVE npm dependencies that
+# Dependabot cannot bump because a parent pins them (e.g. undici/sharp pinned by
+# wrangler). Adds a semver-safe npm `overrides` entry per vulnerable leaf, opens
+# a PR (via the PAT so CI runs), and enables auto-merge. Anything needing a MAJOR
+# bump is left for review as a tracking issue — never auto-applied.
+
+on:
+  schedule:
+    - cron: "0 6 * * 2" # Tuesdays 06:00 UTC (after Dependabot's Monday run)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-patch-deps
+  cancel-in-progress: false
+
+env:
+  ESCALATION_ISSUE_TITLE: "Dependencies needing a major bump for security"
+
+jobs:
+  patch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # PAT so the PR this workflow opens actually triggers CI + can auto-merge
+          token: ${{ secrets.GH_PUSH_TOKEN }}
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+
+      - name: Scan + patch transitive deps
+        working-directory: worker
+        run: node ../scripts/audit-fix-overrides.mjs
+
+      - name: Read result
+        id: result
+        run: |
+          set -euo pipefail
+          test -f audit-result.json || echo '{"changed":false,"applied":[],"escalate":[]}' > audit-result.json
+          echo "changed=$(jq -r '.changed' audit-result.json)" >> "$GITHUB_OUTPUT"
+          echo "n_escalate=$(jq -r '.escalate | length' audit-result.json)" >> "$GITHUB_OUTPUT"
+          {
+            echo 'summary<<EOF'
+            echo '### Applied (semver-safe, in-major)'; jq -r '.applied[]? // "  (none)" | "- \(.)"' audit-result.json
+            echo; echo '### Escalated (needs a major bump — not auto-applied)'; jq -r '.escalate[]? // "  (none)" | "- \(.)"' audit-result.json
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open PR + enable auto-merge
+        if: steps.result.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="auto-patch/worker-deps-$(date -u +%Y%m%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add worker/package.json worker/package-lock.json
+          git commit -m "fix(worker): auto-patch vulnerable transitive deps via overrides"
+          git push -u origin "$BRANCH" --force-with-lease
+          gh pr create --base master --head "$BRANCH" \
+            --title "fix(worker): auto-patch vulnerable transitive deps" \
+            --label dependencies --label security \
+            --body "$(cat <<PRBODY
+          Automated fix for security advisories on the worker's **transitive** npm deps that Dependabot can't bump (a parent pins them). Each vulnerable leaf is overridden to the latest version **within its current major** (semver-safe), and the lockfile is regenerated.
+
+          ${{ steps.result.outputs.summary }}
+
+          CI (Quality Gate, Vuln Scan, Cloudflare Pages build) gates this before auto-merge. If the build breaks, the PR stays open for review.
+          PRBODY
+          )"
+          gh pr merge --auto --squash "$BRANCH" || echo "auto-merge not enabled yet; PR left open"
+
+      - name: Escalate un-fixable advisories (tracking issue)
+        if: steps.result.outputs.n_escalate != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
+        run: |
+          set -euo pipefail
+          BODY=$(jq -r '"These worker dependencies have security advisories with **no in-major fix** — they need a major bump (manual review), which this automation will not apply:\n\n" + (.escalate | map("- " + .) | join("\n")) + "\n\n_Maintained by the Auto-patch worker deps workflow._' audit-result.json)
+          EXISTING=$(gh issue list --state open --search "$ESCALATION_ISSUE_TITLE in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body "$BODY"
+            echo "updated issue #$EXISTING"
+          else
+            gh issue create --title "$ESCALATION_ISSUE_TITLE" --label security --body "$BODY"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ sentrux-test
 
 # Trivy - ephemeral scan JSON (dashboard SVG is committed, raw JSON is not)
 .trivy/
+
+# Transient artifact from scripts/audit-fix-overrides.mjs
+audit-result.json

--- a/scripts/audit-fix-overrides.mjs
+++ b/scripts/audit-fix-overrides.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Auto-patch the worker's vulnerable transitive dependencies.
+//
+// Dependabot cannot bump deps that a parent pins (e.g. undici/sharp pinned by
+// wrangler), so security advisories on them linger until wrangler updates. This
+// bumps each vulnerable LEAF package to the newest version WITHIN ITS CURRENT
+// MAJOR via an npm `overrides` entry, then lets `npm audit` confirm the result.
+//
+// - Only "leaf" packages (those with their own advisory) are touched; parent
+//   packages flagged merely for containing a vulnerable child are fixed
+//   transitively once the leaf is overridden.
+// - Only IN-MAJOR bumps are applied automatically (semver-safe). Anything still
+//   vulnerable after that — i.e. needs a MAJOR bump or has no fix — is returned
+//   in `escalate` for human review, never auto-applied.
+// Run from the worker/ directory.
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const sh = (c) => execSync(c, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+const auditJson = () => { try { return JSON.parse(sh('npm audit --json')); } catch (e) { try { return JSON.parse(e.stdout || '{}'); } catch { return {}; } } };
+const lockVersion = (name) => {
+  const lock = JSON.parse(readFileSync('package-lock.json', 'utf8'));
+  return Object.entries(lock.packages || {})
+    .filter(([k]) => k.endsWith('node_modules/' + name)).map(([, v]) => v.version)
+    .filter(Boolean).sort((a, b) => a.localeCompare(b, undefined, { numeric: true })).pop();
+};
+const latestInMajor = (name, major) => {
+  const all = JSON.parse(sh(`npm view ${name} versions --json`));
+  return (Array.isArray(all) ? all : [all])
+    .filter((v) => /^\d+\.\d+\.\d+$/.test(v) && v.split('.')[0] === String(major))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true })).pop();
+};
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+pkg.overrides = pkg.overrides || {};
+const before = JSON.stringify(pkg.overrides);
+const applied = [];
+
+// Pass 1 — override each vulnerable LEAF to the latest in-major version.
+for (const [name, v] of Object.entries(auditJson().vulnerabilities || {})) {
+  if (v.severity === 'info') continue;
+  const isLeaf = (v.via || []).some((x) => typeof x === 'object'); // has its own advisory
+  if (!isLeaf) continue; // parent — resolved transitively when the leaf is fixed
+  const installed = lockVersion(name);
+  if (!installed) continue;
+  let cand = null;
+  try { cand = latestInMajor(name, installed.split('.')[0]); } catch {}
+  if (cand && cand.localeCompare(installed, undefined, { numeric: true }) > 0) {
+    pkg.overrides[name] = cand;
+    applied.push(`${name}: ${installed} -> ${cand} (${v.severity})`);
+  }
+}
+
+let changed = JSON.stringify(pkg.overrides) !== before;
+if (changed) {
+  writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+  execSync('npm install --package-lock-only --ignore-scripts', { stdio: 'inherit' });
+}
+
+// Escalate = whatever remains vulnerable AFTER the in-major overrides (leaves only).
+const escalate = [];
+for (const [name, v] of Object.entries(auditJson().vulnerabilities || {})) {
+  if (v.severity === 'info') continue;
+  if (!(v.via || []).some((x) => typeof x === 'object')) continue;
+  escalate.push(`${name} (${v.severity}): no in-major fix — needs a major bump / manual review`);
+}
+
+writeFileSync('../audit-result.json', JSON.stringify({ changed, applied, escalate }, null, 2));
+console.log('APPLIED:', applied.length ? '' : '(none)'); applied.forEach((a) => console.log('  ' + a));
+console.log('ESCALATE:', escalate.length ? '' : '(none)'); escalate.forEach((e) => console.log('  ' + e));
+console.log('CHANGED=' + changed);


### PR DESCRIPTION
## What
A tiny scheduled job that keeps the worker's **transitive** npm deps patched — the ones Dependabot can't touch because a parent (wrangler) pins them (this is exactly what `undici` and `sharp` have needed manually).

## How it works
- **`scripts/audit-fix-overrides.mjs`** — reads `npm audit --json`, and for each vulnerable **leaf** package overrides it to the newest version **within its current major** (semver-safe), then regenerates the lockfile. A post-fix re-audit decides escalation: anything still vulnerable needs a **major** bump and is *never* auto-applied — it's reported for review instead.
- **`.github/workflows/auto-patch-deps.yml`** — runs weekly (Tue 06:00 UTC, after Dependabot's Monday) + `workflow_dispatch`. Hardened runner, pinned action SHAs. If overrides changed → opens a PR via `GH_PUSH_TOKEN` (so CI actually runs) and enables `--auto --squash`, so it merges itself only once **Quality Gate + Vuln Scan + Pages build** are green. If something needs a major bump → upserts one tracking issue.

## Safety
- Only in-major (semver-safe) bumps are ever applied automatically.
- Every change is CI-gated before auto-merge; a broken build leaves the PR open.
- €0 — GitHub Actions only, no Cloudflare cost.

## Validation
Ran the script against current `master`: **no-op** (`CHANGED=false`) — the `undici ^7.29.0` override from #134 is already the latest in-major, so the first scheduled run will correctly do nothing.