### PR TITLE
chore: point aboutcloud.io links from blog. to www.

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1474,7 +1474,7 @@
         </div>
       </div>
       <div class="header-right">
-        <a href="https://blog.aboutcloud.io" target="_blank" rel="noopener" class="ac-brand">
+        <a href="https://www.aboutcloud.io" target="_blank" rel="noopener" class="ac-brand">
           <img src="assets/logo_200x200_white.png" alt="aboutcloud.io" />
           aboutcloud.io
         </a>
@@ -1721,7 +1721,7 @@
         <div class="tool-name">EntraPass</div>
         <div class="tool-desc">Passkey readiness scanner for Entra ID</div>
       </a>
-      <a href="https://blog.aboutcloud.io" target="_blank" rel="noopener" class="tool-card">
+      <a href="https://www.aboutcloud.io" target="_blank" rel="noopener" class="tool-card">
         <div class="tool-name">aboutcloud.io</div>
         <div class="tool-desc">Entra ID · Security · Cloud</div>
       </a>
@@ -1734,7 +1734,7 @@
   <div class="container">
     <div class="footer-inner">
       <span class="footer-text">Data sourced from Microsoft's official documentation · Refreshed daily · Not affiliated with or endorsed by Microsoft</span>
-      <a href="https://blog.aboutcloud.io" target="_blank" rel="noopener" class="footer-link">aboutcloud.io</a>
+      <a href="https://www.aboutcloud.io" target="_blank" rel="noopener" class="footer-link">aboutcloud.io</a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Repoints links from the retiring `blog.aboutcloud.io` to `www.aboutcloud.io`.

- Literal domain swap; paths left unchanged.
- Frontend anchor/href links updated.
- Worker `ALLOWED_ORIGINS` CORS entry updated where present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)