### PR TITLE
fix(pipeline): retry Cloudflare D1/KV pushes on transient 5xx/429

### DIFF
--- a/pipeline/push_to_cloudflare.py
+++ b/pipeline/push_to_cloudflare.py
@@ -22,8 +22,10 @@ Actual D1 schema (queried from live DB):
 import json
 import math
 import os
+import random
 import re
 import sys
+import time
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timedelta, timezone
@@ -37,6 +39,139 @@ CHANGELOG_PATH = DATA_DIR / "changelog.json"
 
 CF_BASE = "https://api.cloudflare.com/client/v4"
 D1_WORKERS = 8
+
+GH_API = "https://api.github.com"
+FAILURE_ISSUE_TITLE = "Cloudflare push failures in nightly pipeline"
+FAILURE_ISSUE_LABEL = "pipeline-failure"
+
+RETRY_ATTEMPTS = 3
+RETRY_BASE_DELAY = 1.0  # seconds; doubles each attempt, plus jitter
+RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+
+
+def with_retry(func, *args, **kwargs):
+    """Call func(*args, **kwargs), retrying on transient Cloudflare errors.
+
+    Retries on HTTP 429/5xx (raised as RuntimeError("HTTP <code>: ...") by
+    d1_exec/kv_put) and on requests.RequestException (connection blips).
+    Any other failure (e.g. a genuine 4xx from bad input) raises immediately.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1, RETRY_ATTEMPTS + 1):
+        try:
+            return func(*args, **kwargs)
+        except (RuntimeError, requests.RequestException) as exc:
+            msg = str(exc)
+            is_retryable = isinstance(exc, requests.RequestException) or any(
+                msg.startswith(f"HTTP {code}") for code in RETRYABLE_STATUS
+            )
+            if not is_retryable or attempt == RETRY_ATTEMPTS:
+                raise
+            last_exc = exc
+            delay = RETRY_BASE_DELAY * (2 ** (attempt - 1)) + random.uniform(0, 0.5)
+            print(f"    transient error ({msg[:120]}), retrying in {delay:.1f}s "
+                  f"(attempt {attempt}/{RETRY_ATTEMPTS})", file=sys.stderr)
+            time.sleep(delay)
+    raise last_exc  # pragma: no cover — loop always returns or raises above
+
+
+def upsert_failure_issue(failures: list[str]) -> None:
+    """Idempotent issue for Cloudflare push failures that survived retries.
+
+    Mirrors coverage_report.upsert_issue()'s find-by-title-and-label,
+    PATCH-or-POST pattern so a real (non-transient) failure is visible on
+    GitHub instead of only living in Actions logs. No-op without credentials.
+    """
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPO") or os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repo:
+        print("  (GITHUB_TOKEN/GITHUB_REPO not set -- skipping failure issue upsert)")
+        return
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    existing = None
+    q = requests.get(
+        f"{GH_API}/repos/{repo}/issues",
+        headers=headers,
+        params={"state": "open", "labels": FAILURE_ISSUE_LABEL, "per_page": 100},
+        timeout=15,
+    )
+    if q.ok:
+        for it in q.json():
+            if it.get("title") == FAILURE_ISSUE_TITLE and "pull_request" not in it:
+                existing = it
+                break
+
+    lines = [
+        f"The nightly pipeline's push to Cloudflare KV/D1 failed on {NOW} after "
+        f"{RETRY_ATTEMPTS} retries per statement.",
+        "",
+        "```",
+        *failures[:10],
+        "```",
+        "",
+        "_Maintained automatically by `push_to_cloudflare.py`. Closes itself on the "
+        "next successful push._",
+    ]
+    body = "\n".join(lines)
+
+    if existing:
+        requests.patch(
+            f"{GH_API}/repos/{repo}/issues/{existing['number']}",
+            headers=headers,
+            json={"body": body, "state": "open"},
+            timeout=15,
+        )
+        print(f"  Failure issue #{existing['number']} updated.")
+    else:
+        resp = requests.post(
+            f"{GH_API}/repos/{repo}/issues",
+            headers=headers,
+            json={"title": FAILURE_ISSUE_TITLE, "body": body, "labels": [FAILURE_ISSUE_LABEL]},
+            timeout=15,
+        )
+        if resp.ok:
+            print(f"  Failure issue opened: {resp.json().get('html_url', '')}")
+        else:
+            print(f"  Failed to open failure issue: HTTP {resp.status_code}", file=sys.stderr)
+
+
+def close_failure_issue() -> None:
+    """Close the failure issue (if open) after a clean push — self-healing."""
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPO") or os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repo:
+        return
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    q = requests.get(
+        f"{GH_API}/repos/{repo}/issues",
+        headers=headers,
+        params={"state": "open", "labels": FAILURE_ISSUE_LABEL, "per_page": 100},
+        timeout=15,
+    )
+    if not q.ok:
+        return
+    for it in q.json():
+        if it.get("title") == FAILURE_ISSUE_TITLE and "pull_request" not in it:
+            requests.patch(
+                f"{GH_API}/repos/{repo}/issues/{it['number']}",
+                headers=headers,
+                json={"state": "closed",
+                      "body": "Push succeeded on a later run. ✅\n\n"
+                              "_Closed automatically by `push_to_cloudflare.py`._"},
+                timeout=15,
+            )
+            print(f"  Failure issue #{it['number']} closed (push succeeded).")
+            break
 
 TODAY = date.today().isoformat()
 NOW = datetime.now(timezone.utc).isoformat()
@@ -138,8 +273,8 @@ def compute_bm25_stats(tasks: list[dict]) -> tuple[dict, dict, dict]:
 # KV
 # ---------------------------------------------------------------------------
 
-def kv_put(account_id: str, namespace_id: str, token: str,
-           key: str, value: str) -> None:
+def _kv_put_once(account_id: str, namespace_id: str, token: str,
+                  key: str, value: str) -> None:
     url = (f"{CF_BASE}/accounts/{account_id}/storage/kv"
            f"/namespaces/{namespace_id}/values/{key}")
     resp = requests.put(
@@ -148,10 +283,19 @@ def kv_put(account_id: str, namespace_id: str, token: str,
         data=value.encode("utf-8"),
         timeout=30,
     )
-    print(f"  KV PUT {key!r}: HTTP {resp.status_code}")
     if not resp.ok:
-        print(f"    {resp.text}", file=sys.stderr)
+        raise RuntimeError(f"HTTP {resp.status_code}: {resp.text}")
+
+
+def kv_put(account_id: str, namespace_id: str, token: str,
+           key: str, value: str) -> None:
+    try:
+        with_retry(_kv_put_once, account_id, namespace_id, token, key, value)
+    except (RuntimeError, requests.RequestException) as exc:
+        print(f"  KV PUT {key!r}: FAILED after retries -- {exc}", file=sys.stderr)
+        upsert_failure_issue([f"KV PUT {key!r}: {exc}"])
         sys.exit(1)
+    print(f"  KV PUT {key!r}: OK")
 
 
 # ---------------------------------------------------------------------------
@@ -200,21 +344,22 @@ def d1_run_many(account_id: str, database_id: str, token: str,
     errors: list[str] = []
 
     def run_one(stmt: dict) -> None:
-        d1_exec(account_id, database_id, token,
-                stmt["sql"], stmt.get("params"))
+        with_retry(d1_exec, account_id, database_id, token,
+                   stmt["sql"], stmt.get("params"))
 
     with ThreadPoolExecutor(max_workers=D1_WORKERS) as pool:
         futures = {pool.submit(run_one, s): i for i, s in enumerate(statements)}
         for future in as_completed(futures):
             try:
                 future.result()
-            except RuntimeError as exc:
+            except (RuntimeError, requests.RequestException) as exc:
                 errors.append(str(exc))
 
     print(f"  D1 {label}: {len(statements)} stmts, {len(errors)} errors")
     if errors:
         for e in errors[:5]:
             print(f"    {e}", file=sys.stderr)
+        upsert_failure_issue([f"{label}: {e}" for e in errors[:10]])
         sys.exit(1)
 
 
@@ -659,6 +804,7 @@ def main() -> None:
     update_readme_whats_new(CHANGELOG_PATH, readme_path)
     update_readme_data_quality(MASTER_PATH, readme_path)
     update_readme_sentrux(readme_path)
+    close_failure_issue()
 
     print("Push complete")
 

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -4,5 +4,5 @@
 # packages were unpinned) and makes builds reproducible.
 requests==2.34.2
 beautifulsoup4==4.15.0
-lxml==6.1.2
+lxml==6.1.3
 azure-identity==1.25.3

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260826.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260826.1.tgz",
-      "integrity": "sha512-8UsGGY8ZUiYHOWdsxBlNsGmaHBGArVwJ3CM4nWpfBhthjjYe4M/OqrTpqKF7NNWb63qQiv1d8Z+Z6/hmUqNKIQ==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260903.1.tgz",
+      "integrity": "sha512-FG+4mGxAXhKiL/1temH42alevIkumtYXNidhTa//3yULpzux6APw5UNVocI/vCQ1yG1YOEZRfbVy8lyuipM9MQ==",
       "cpu": [
         "x64"
       ],
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260826.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260826.1.tgz",
-      "integrity": "sha512-0bLqVQYsQ3v3FdYGmzh23vi9fJeYTBx19o4LUySIsRcgBggGSlR39ml162vTXvZzUISOjVW2qfL7Y+SMrrfXmQ==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-o241VefnjG8eG+kGap5CjgV4zOT5UaAmS3OR1VZCpNj7vkXGxvp9KftKvtQgcCsIqJKaKx+7Xd7xq0L1DjkfPQ==",
       "cpu": [
         "arm64"
       ],
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260826.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260826.1.tgz",
-      "integrity": "sha512-DTC0yWzybX4gUH5Q1pJo3UwEQjp0Gmz0Q71I+39xT9SXBesX5QndOIQv45yHQ86Z84EzK2WwaENdlpmDSvJKmw==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260903.1.tgz",
+      "integrity": "sha512-/VEvvtQ/XKf6HlBbg6FbvpwcpfYUcx6Fv6RkASY8DyEmUyuJ8rc7Qxil83ClRFoBzz/GY0BV94UZ6F+wers/hg==",
       "cpu": [
         "x64"
       ],
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260826.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260826.1.tgz",
-      "integrity": "sha512-PFerWi+DP2Ckc6eATAS4dhotBt8IeXJjTzIgy18H+uqsswlXc7A8HsnAunHL9v/7/BjCgq46iMo2g4iUAsEpDw==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-OWhihGC6KoTXF4u2C1AonfpgXeM4/7p/1IXuALqXESmFUpLLP5gZhRzjSk/gWW+mrCZDfSrvnjifl+lRqselbA==",
       "cpu": [
         "arm64"
       ],
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260826.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260826.1.tgz",
-      "integrity": "sha512-X26hulrG2MSSfpRmjZbCq98LNaZnrRqbmGcgo7g1U/U0nJ5npYruPm3fAyZ2y6VDr5CmQo9BLCahxP8VB/QR6A==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260903.1.tgz",
+      "integrity": "sha512-soPMF9/aMHlHKK7M0vq5HrRRicPbnZO1F6ZZ7JWN8EltxWJU5L7CEq7CxjO878DzyPx7gYvqBFy3SVgdZKZjMQ==",
       "cpu": [
         "x64"
       ],
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260828.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260828.1.tgz",
-      "integrity": "sha512-Ce0QfghuAK9v821gER8rFPR3rMeC+5puTgTzCu4UrG1Zg967Z5Aa+2uZVciIyfCAdGssyh+sLEC6rMjN/YBQwA==",
+      "version": "5.20260905.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260905.1.tgz",
+      "integrity": "sha512-ebDpVTgrnee245IRBTazyfjfmZas+HJehZyVQkKmUozsBN8RzvXXMI0XjjcT2rQjw+0USewfEGGLYiHO+TL0Sg==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -1698,16 +1698,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260826.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260826.0-alpha.tgz",
-      "integrity": "sha512-ZXR3Bieg+B5MK0T/zYIWaZiCGCb9Z3en4+/TleYKhIGPLx/e0cRcG/ZvvTviUapVBBK2zODB+aiypdIojU3x6Q==",
+      "version": "5.20260903.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260903.0-alpha.tgz",
+      "integrity": "sha512-VCZIFxOqFXeibRBJWwTlppqbv2lkeO10IX3QBRGK9j1QiMAfH/OSsCvbjp1MslBMhVZmy2VTRlVaVnsKnbDp6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260826.1",
+        "workerd": "1.20260903.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1844,9 +1844,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1864,9 +1864,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260826.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260826.1.tgz",
-      "integrity": "sha512-oTG9ot5zxO9OjjKCskt86+nVrBL0kiUqExHnYaTg4OCkHf/K4zr+9hYvgwmG8DdCWG0TQGErHzD+1h50TM5b+w==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260903.1.tgz",
+      "integrity": "sha512-xJzt2RnCy7ulOULmZy/4JLbEPg1uisp9lVoOUsEz+UVhDsTmrSQ0rBXZMGcXuhr2HCGKs89bg8nnbbzvBSX1Ig==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1877,17 +1877,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260826.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260826.1",
-        "@cloudflare/workerd-linux-64": "1.20260826.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260826.1",
-        "@cloudflare/workerd-windows-64": "1.20260826.1"
+        "@cloudflare/workerd-darwin-64": "1.20260903.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260903.1",
+        "@cloudflare/workerd-linux-64": "1.20260903.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260903.1",
+        "@cloudflare/workerd-windows-64": "1.20260903.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.127.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.127.0.tgz",
-      "integrity": "sha512-4dPqcBEMJfGeZeNnjHT7ThNJs+EiNYxUTg4ywqIdQubcXHBhFeVMQyHV4A9AOhZRFr83cckqdds034KGcr/dtw==",
+      "version": "4.129.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.129.0.tgz",
+      "integrity": "sha512-PGPvs9UPoFrwxT0VogpESSZGvZIctAuTK3wGsLLPHtHsSgS85kNdvtpa2d14UzG8gwLWD64XUGFPGG9tOXG9VQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1895,10 +1895,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260826.0-alpha",
+        "miniflare": "5.20260903.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260826.1"
+        "workerd": "1.20260903.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1912,7 +1912,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260826.1"
+        "@cloudflare/workers-types": "^5.20260903.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,6 +1,9 @@
 name = "rolelens-worker"
 main = "src/index.ts"
-compatibility_date = "2024-01-01"
+compatibility_date = "2026-09-05"
+
+[observability]
+enabled = true
 
 [[d1_databases]]
 binding  = "DB"


### PR DESCRIPTION
## Summary
- Nightly `refresh.yml` failed twice recently (2026-08-31, 2026-09-05) at the "Push to Cloudflare KV and D1" step on a transient Cloudflare `500` during the roles D1 batch upsert. There was no retry logic anywhere in `pipeline/push_to_cloudflare.py`, so a single transient error aborted the whole job and skipped committing `data/` back to master — causing repo/live drift.
- Added `with_retry()` (exponential backoff + jitter, 3 attempts) around every D1 statement and KV write. Retries only on `429`/`5xx`/connection errors; a genuine 4xx still fails immediately.
- Added `upsert_failure_issue()` / `close_failure_issue()`, patterned directly on `coverage_report.py`'s existing idempotent-issue logic, so a failure that survives retries opens a visible GitHub issue instead of only living in Actions logs, and self-closes on the next clean push.
- `worker/wrangler.toml`: bumped `compatibility_date` (was pinned at `2024-01-01`), added `[observability] enabled = true` for Workers Logs visibility into exactly this class of issue going forward.
- Dependency bumps (patch/minor only, matching the project's existing Dependabot policy): wrangler 4.127.0→4.129.0, `@cloudflare/workers-types`→5.20260905.1, `lxml` 6.1.2→6.1.3.

## Test plan
- [x] `python3 -m py_compile pipeline/push_to_cloudflare.py`
- [x] Isolated unit test of `with_retry()`: confirms it retries transient 500s to success, does not retry a 403, and raises after exhausting retries on a persistent 500
- [x] `npm run type-check` in `worker/` — clean
- [x] `npx wrangler deploy --dry-run` in `worker/` — validates new `wrangler.toml` (compatibility_date + observability block), bindings resolve correctly
- [ ] CI (vuln-scan, config-scan, quality-gate) green on this PR
- [ ] After merge: manually trigger `refresh.yml` to confirm the D1 push step succeeds and reconciles the 1-day-stale `data/` snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)