### PR TITLE
feat(frontend): add security-focused example pills and diff pairs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1617,6 +1617,10 @@
         <button class="pill-btn" onclick="runPillSearch('configure GDAP')">configure GDAP</button>
         <button class="pill-btn" onclick="runPillSearch('backup Entra directory')">backup Entra directory</button>
         <button class="pill-btn" onclick="runPillSearch('restore deleted objects')">restore deleted objects</button>
+        <button class="pill-btn" onclick="runPillSearch('SOC incident response')">SOC incident response</button>
+        <button class="pill-btn" onclick="runPillSearch('read risky sign-ins')">read risky sign-ins</button>
+        <button class="pill-btn" onclick="runPillSearch('fix vulnerability')">fix vulnerability</button>
+        <button class="pill-btn" onclick="runPillSearch('dismiss risk detections')">dismiss risk detections</button>
       </div>
 
       <div id="search-results"></div>
@@ -1657,6 +1661,10 @@
         <button class="pill-btn" onclick="runDiffPill('Entra Backup Administrator','Entra Backup Reader')">Entra Backup Administrator vs Entra Backup Reader</button>
         <button class="pill-btn" onclick="runDiffPill('Tenant Governance Administrator','Tenant Governance Reader')">Tenant Governance Admin vs Tenant Governance Reader</button>
         <button class="pill-btn" onclick="runDiffPill('Global Administrator','Agent Registry Administrator')">Global Admin vs Agent Registry Administrator</button>
+        <button class="pill-btn" onclick="runDiffPill('Global Secure Access Administrator','Global Secure Access Log Reader')">Global Secure Access Admin vs Log Reader</button>
+        <button class="pill-btn" onclick="runDiffPill('Purview Workload Content Administrator','Purview Workload Content Reader')">Purview Workload Content Admin vs Reader</button>
+        <button class="pill-btn" onclick="runDiffPill('Purview Workload Content Reader','Purview Workload Content Writer')">Purview Workload Content Reader vs Writer</button>
+        <button class="pill-btn" onclick="runDiffPill('Entra SOC Identity Responder','Security Reader')">SOC Identity Responder vs Security Reader</button>
       </div>
 
       <div class="diff-inputs">

--- a/pipeline/test_pills.py
+++ b/pipeline/test_pills.py
@@ -35,6 +35,10 @@ EXPECTATIONS: list[tuple[str, str]] = [
     ("audit AI usage",              "AI Reader"),
     ("configure PIM",               "Privileged Role Administrator"),
     ("approve access review",       "Identity Governance Administrator"),
+    ("SOC incident response",       "Entra SOC Identity Responder"),
+    ("read risky sign-ins",         "Security Reader"),
+    ("fix vulnerability",            "Security Administrator"),
+    ("dismiss risk detections",     "Security Operator"),
 ]
 
 # Pills that are known to fail and are tracked as Week 2 work.


### PR DESCRIPTION
## Summary
- Added 4 new Task→Role example pills covering security scenarios not previously represented on the page: `SOC incident response` → Entra SOC Identity Responder, `read risky sign-ins` → Security Reader, `fix vulnerability` → Security Administrator, `dismiss risk detections` → Security Operator (a role with zero presence anywhere on the page until now).
- Added 4 new Role Diff pairs: Global Secure Access Administrator vs Log Reader, Purview Workload Content Administrator vs Reader, Purview Workload Content Reader vs Writer, and Entra SOC Identity Responder vs Security Reader.
- Every new pill was verified against the **live** `/api/search` endpoint (through the same `expand_query()` synonym-expansion path `pipeline/test_pills.py` uses) before being finalized — one candidate (`configure sign-in risk policy`) resolved to the wrong role after synonym expansion and was swapped for `fix vulnerability`, which resolves correctly. Corresponding `EXPECTATIONS` entries added to `pipeline/test_pills.py` per that file's own instruction comment.
- Global Secure Access and Purview Workload Content pills were **not** added: those roles have zero task mappings in the DB today (Microsoft hasn't published delegate-by-task entries, and they're not in `MANUAL_FEATURE_AREAS`), so no query wording can resolve to them via search — only the Role Diff comparisons work for them right now.

## Test plan
- [x] `WORKER_URL=https://rolelens-worker.russo-antonio76.workers.dev python3 pipeline/test_pills.py` — 19/19 pass, 0 regressions
- [x] Verified all 4 new Role Diff pairs resolve via live `/api/diff?a=...&b=...`
- [ ] CI (vuln-scan, config-scan, quality-gate) green on this PR
- [ ] Manually click each new pill and diff pair on the merged preview/prod site

🤖 Generated with [Claude Code](https://claude.com/claude-code)