### PR TITLE
fix(pipeline): switch Workers AI model to @cf/meta/llama-3.2-3b-instruct

### DIFF
--- a/pipeline/generate_scenarios.py
+++ b/pipeline/generate_scenarios.py
@@ -25,7 +25,7 @@ CHANGELOG_PATH = DATA_DIR / "changelog.json"
 ROLES_PATH = DATA_DIR / "roles.json"
 
 CF_BASE = "https://api.cloudflare.com/client/v4"
-MODEL = "@cf/meta/llama-3.1-8b-instruct-fast"
+MODEL = "@cf/meta/llama-3.2-3b-instruct"
 
 
 def generate_scenario(role: dict, account_id: str, token: str) -> str | None:


### PR DESCRIPTION
Automated: the Workers AI model configured in `generate_scenarios.py` was deprecated or removed from Cloudflare's catalog. Switched to `@cf/meta/llama-3.2-3b-instruct`, the first candidate in `check_ai_model.py`'s `CANDIDATES` list that is active in the current catalog and passed a live smoke test.

CI (Quality Gate, Vuln Scan, Cloudflare Pages build) gates this before auto-merge. If the build breaks, the PR stays open for review.