### PR TITLE
docs: give the infrastructure diagram its own section again

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ How the frontend, Worker API, and D1/KV actually connect — and where the night
 
 [![Application architecture](assets/app-architecture.svg)](assets/app-architecture.svg)
 
-For the hosting/cost picture (which free tier runs what) see [Technical stack](#technical-stack) below, or the [infrastructure diagram](assets/architecture.svg).
+### Infrastructure & cost
+
+Which free tier hosts what, and how the nightly pipeline authenticates to Microsoft without storing a credential:
+
+[![Infrastructure architecture](assets/architecture.svg)](assets/architecture.svg)
+
+See [Technical stack](#technical-stack) below for the full per-layer cost breakdown, and [Passwordless pipeline](#passwordless-pipeline--how-authentication-works) for the OIDC handshake in detail.
 
 ---
 


### PR DESCRIPTION
## Summary
Follow-up to #155 based on feedback: the infrastructure/hosting diagram (`assets/architecture.svg`) got reduced to a single inline link when `app-architecture.svg` was added, when it should stay presented as a peer to the other two diagrams, not demoted. Restored as its own "Infrastructure & cost" subsection with the image embedded, matching the treatment given to Application architecture and AI automation engine.

## Test plan
- [ ] CI green
- [ ] Visual check: README renders all three diagrams with equal-weight sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)