### PR TITLE
fix(frontend): remove Trivy status bar, enlarge What's New panel

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -804,8 +804,9 @@
 
     /* ── What's New panel ──────────────────────────────────────────── */
     .whats-new-panel {
-      background: var(--surface);
+      background: var(--surface2);
       border: 1px solid var(--border);
+      border-left: 3px solid var(--accent-dim);
       border-radius: var(--radius-lg);
       margin-bottom: 28px;
       overflow: hidden;
@@ -818,15 +819,15 @@
       display: flex;
       flex-direction: column;
       align-items: stretch;
-      padding: 14px 20px 12px;
+      padding: 18px 24px 16px;
       background: none;
       border: none;
       color: var(--text);
       cursor: pointer;
       text-align: left;
-      gap: 3px;
+      gap: 5px;
     }
-    .whats-new-header:hover { background: var(--surface2); }
+    .whats-new-header:hover { background: rgba(255,255,255,0.02); }
 
     .wn-title-row {
       display: flex;
@@ -836,21 +837,22 @@
     }
     .wn-title {
       font-family: var(--font-mono);
-      font-size: 13px;
-      font-weight: 600;
-      color: var(--text);
+      font-size: 17px;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+      color: var(--accent);
     }
-    .whats-new-chevron { color: var(--muted); transition: transform 0.2s; flex-shrink: 0; }
+    .whats-new-chevron { color: var(--muted); transition: transform 0.2s; flex-shrink: 0; width: 18px; height: 18px; }
     .whats-new-chevron.open { transform: rotate(180deg); }
 
     .wn-subtitle {
       font-family: var(--font-body);
-      font-size: 12px;
+      font-size: 14px;
       color: var(--muted);
     }
 
     .whats-new-body {
-      padding: 4px 20px 8px;
+      padding: 6px 24px 14px;
       border-top: 1px solid var(--border);
     }
 
@@ -861,14 +863,15 @@
     .whats-new-entry {
       display: flex;
       align-items: center;
-      gap: 10px;
-      padding: 9px 0;
-      font-size: 14px;
+      gap: 12px;
+      padding: 13px 4px;
+      font-size: 15.5px;
+      border-radius: 6px;
     }
 
     /* Expandable rows: chevron affordance + click-to-open detail. */
     .wn-chev, .wn-chev-spacer {
-      width: 16px;
+      width: 18px;
       flex-shrink: 0;
       text-align: center;
       transition: transform 0.18s ease, color 0.18s ease;
@@ -876,29 +879,29 @@
     .wn-chev {
       color: var(--text);
       opacity: 0.5;
-      font-size: 14px;
+      font-size: 15px;
       line-height: 1;
     }
     .wn-item.wn-open .wn-chev { transform: rotate(90deg); color: var(--accent); opacity: 1; }
     .wn-expandable > .whats-new-entry { cursor: pointer; border-radius: 6px; }
-    .wn-expandable > .whats-new-entry:hover { background: var(--surface2); }
+    .wn-expandable > .whats-new-entry:hover { background: rgba(255,255,255,0.04); }
     .wn-expandable > .whats-new-entry:hover .wn-chev { color: var(--accent); opacity: 1; }
     .wn-expandable > .whats-new-entry:focus-visible {
       outline: 1px solid var(--accent); outline-offset: -1px;
     }
 
     /* Expanded "what exactly changed" detail (block flow — not flex column). */
-    .wn-detail { padding: 2px 0 12px 26px; }
+    .wn-detail { padding: 2px 0 14px 30px; }
     .wn-detail[hidden] { display: none; }
 
     .wn-pgroup { margin-top: 8px; }
     .wn-pgroup:first-child { margin-top: 2px; }
     .wn-phead {
       font-family: var(--font-mono);
-      font-size: 10px;
+      font-size: 11.5px;
       text-transform: uppercase;
       letter-spacing: 0.06em;
-      margin-bottom: 4px;
+      margin-bottom: 5px;
       opacity: 0.85;
     }
     .wn-phead.added   { color: var(--added); }
@@ -906,8 +909,8 @@
     .wn-perm {
       display: block;
       font-family: var(--font-mono);
-      font-size: 11.5px;
-      line-height: 1.55;
+      font-size: 13px;
+      line-height: 1.65;
       color: var(--muted);
       word-break: break-all;
     }
@@ -916,14 +919,14 @@
     .wn-perm .wn-sign { display: inline-block; width: 12px; font-weight: 700; }
     .wn-perm-rest[hidden] { display: none; }
     .wn-more-btn {
-      margin-top: 4px;
+      margin-top: 6px;
       background: none;
       border: 1px solid var(--border);
       border-radius: 6px;
       color: var(--muted);
       font-family: var(--font-mono);
-      font-size: 11px;
-      padding: 2px 8px;
+      font-size: 12.5px;
+      padding: 3px 10px;
       cursor: pointer;
     }
     .wn-more-btn:hover { color: var(--text); border-color: var(--muted); }
@@ -931,7 +934,7 @@
     /* Word-level diff: full text in context, only changed words highlighted. */
     .wn-worddiff {
       font-family: var(--font-body);
-      font-size: 12px;
+      font-size: 13.5px;
       color: var(--muted);
       line-height: 1.6;
     }
@@ -959,68 +962,68 @@
     .wn-privnote { font-family: var(--font-body); }
     .wn-priv-row {
       font-family: var(--font-mono);
-      font-size: 12px;
+      font-size: 13.5px;
       display: flex;
       align-items: baseline;
       gap: 10px;
     }
     .wn-priv-tag {
       color: var(--muted);
-      font-size: 10px;
+      font-size: 11px;
       text-transform: uppercase;
       letter-spacing: 0.06em;
-      width: 34px;
+      width: 38px;
       flex-shrink: 0;
     }
     .wn-priv-from { color: var(--muted); }
     .wn-priv-to   { color: var(--text); }
     .wn-priv-to.is-priv { color: var(--warn); font-weight: 600; }
-    .wn-priv-why  { font-size: 12px; color: var(--muted); line-height: 1.55; max-width: 70ch; margin-top: 5px; }
+    .wn-priv-why  { font-size: 13.5px; color: var(--muted); line-height: 1.55; max-width: 70ch; margin-top: 5px; }
 
     /* Count badges in the summary row (+N added / −N removed, privileged). */
     .wn-badges { display: inline-flex; gap: 5px; align-items: center; }
     .wn-badge {
       font-family: var(--font-mono);
-      font-size: 10.5px;
+      font-size: 11.5px;
       font-weight: 700;
       line-height: 1.5;
-      padding: 1px 7px;
+      padding: 2px 8px;
       border-radius: 999px;
       white-space: nowrap;
     }
     .wn-badge.add  { color: var(--added); background: rgba(0, 229, 163, 0.13); }
     .wn-badge.rem  { color: var(--danger); background: rgba(248, 113, 113, 0.13); }
     .wn-badge.priv { color: var(--warn);   background: rgba(251, 191, 36, 0.13); }
-    .wn-badge.unpriv { color: var(--muted); background: var(--surface2); }
-    .wn-badge.count { color: var(--text);  background: var(--surface2); }
-    .wn-badge.zero  { color: var(--muted); background: var(--surface2); }
+    .wn-badge.unpriv { color: var(--muted); background: rgba(255,255,255,0.05); }
+    .wn-badge.count { color: var(--text);  background: rgba(255,255,255,0.05); }
+    .wn-badge.zero  { color: var(--muted); background: rgba(255,255,255,0.05); }
     .wn-label-soft { color: var(--muted); }
 
     /* New-role expanded detail (description + permission list / no-perms note). */
-    .wn-role-desc { font-size: 12px; color: var(--muted); line-height: 1.55; margin-bottom: 8px; }
-    .wn-role-note { font-size: 12px; color: var(--muted); line-height: 1.55; font-style: italic; }
+    .wn-role-desc { font-size: 14px; color: var(--muted); line-height: 1.6; margin-bottom: 10px; }
+    .wn-role-note { font-size: 14px; color: var(--muted); line-height: 1.6; font-style: italic; }
 
     /* AI-generated real-world scenario + official docs link for a new role. */
     .wn-scenario {
-      font-size: 12px; color: var(--text); line-height: 1.55; margin-bottom: 10px;
-      padding: 8px 10px; background: var(--surface2); border-radius: 6px;
+      font-size: 14px; color: var(--text); line-height: 1.6; margin-bottom: 12px;
+      padding: 12px 14px; background: rgba(255,255,255,0.03); border-radius: 6px;
       border-left: 2px solid var(--accent);
     }
     .wn-scenario-label {
-      display: flex; align-items: center; gap: 6px; font-size: 10px; text-transform: uppercase;
-      letter-spacing: .04em; color: var(--muted); margin-bottom: 3px;
+      display: flex; align-items: center; gap: 7px; font-size: 11px; text-transform: uppercase;
+      letter-spacing: .04em; color: var(--muted); margin-bottom: 5px;
     }
     .wn-ai-tag {
-      font-size: 9px; text-transform: none; letter-spacing: 0; font-weight: 600;
-      color: var(--accent); background: var(--surface2); border: 1px solid var(--accent);
-      padding: 1px 6px; border-radius: 999px;
+      font-size: 10px; text-transform: none; letter-spacing: 0; font-weight: 600;
+      color: var(--accent); background: rgba(255,255,255,0.03); border: 1px solid var(--accent);
+      padding: 1px 7px; border-radius: 999px;
     }
-    .wn-doclink { display: inline-block; margin-top: 4px; font-size: 12px; color: var(--accent); }
+    .wn-doclink { display: inline-block; margin-top: 6px; font-size: 14px; color: var(--accent); }
     .wn-doclink:hover { text-decoration: underline; }
 
     /* Deterministic role facts (pipeline-computed, never AI-generated). */
-    .wn-facts { display: flex; flex-wrap: wrap; gap: 6px; margin: 10px 0 4px; }
-    .wn-fact-configured { font-size: 11px; color: var(--muted); margin-bottom: 8px; }
+    .wn-facts { display: flex; flex-wrap: wrap; gap: 7px; margin: 12px 0 5px; }
+    .wn-fact-configured { font-size: 13px; color: var(--muted); margin-bottom: 10px; }
 
     .wn-fresh-dot {
       width: 7px;
@@ -1060,15 +1063,15 @@
       to { opacity: 1; transform: translateY(0); }
     }
 
-    .wn-glyph          { font-size: 13px; flex-shrink: 0; width: 16px; text-align: center; color: var(--added); }
+    .wn-glyph          { font-size: 15px; flex-shrink: 0; width: 18px; text-align: center; color: var(--added); }
     .wn-glyph.removed  { color: var(--danger); }
     .wn-glyph.modified { color: var(--warn); }
-    .wn-name   { font-family: var(--font-mono); font-size: 13px; color: var(--text); flex: 1; }
-    .wn-action { font-family: var(--font-body); font-size: 12px; color: var(--muted); }
+    .wn-name   { font-family: var(--font-mono); font-size: 15px; font-weight: 500; color: var(--text); flex: 1; }
+    .wn-action { font-family: var(--font-body); font-size: 13.5px; color: var(--muted); }
     .whats-new-entry.type-added .wn-action    { color: var(--added); opacity: 0.85; }
     .whats-new-entry.type-modified .wn-action { color: var(--warn);   opacity: 0.85; }
     .whats-new-entry.type-removed .wn-action  { color: var(--danger); opacity: 0.85; }
-    .wn-date   { font-family: var(--font-mono); font-size: 11px; color: var(--muted); white-space: nowrap; }
+    .wn-date   { font-family: var(--font-mono); font-size: 13px; color: var(--muted); white-space: nowrap; }
 
     .wn-show-all { display: flex; justify-content: center; padding: 10px 0 4px; }
     .wn-show-all-btn {
@@ -1077,12 +1080,12 @@
       border-radius: 20px;
       color: var(--muted);
       font-family: var(--font-mono);
-      font-size: 11px;
-      padding: 4px 16px;
+      font-size: 12.5px;
+      padding: 5px 18px;
       cursor: pointer;
       transition: background 0.15s, color 0.15s;
     }
-    .wn-show-all-btn:hover { background: var(--surface2); color: var(--text); }
+    .wn-show-all-btn:hover { background: rgba(255,255,255,0.05); color: var(--text); }
 
     /* ── Explainer grid ─────────────────────────────────────────────── */
     .explainer-grid {
@@ -1318,72 +1321,6 @@
     .gh-stat { white-space: nowrap; }
     .gh-stat-sep { color: var(--border); user-select: none; }
 
-    /* ── Sentrux quality strip ──────────────────────────────────────── */
-    /* ── SecDevOps security strip (Trivy) — night-rider ──────────────── */
-    .secops-bar {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      margin-bottom: 20px;
-      padding: 7px 14px;
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent);
-      font-family: var(--font-mono);
-      font-size: 11px;
-      letter-spacing: 0.5px;
-      width: fit-content;
-      max-width: 100%;
-    }
-    .secops-icon  {
-      display: inline-flex; line-height: 1;
-      color: currentColor;
-      filter: drop-shadow(0 0 7px currentColor);
-    }
-    .secops-icon svg { display: block; }
-    .secops-label {
-      color: currentColor;
-      font-weight: 700;
-      font-size: 12px;
-      text-transform: uppercase;
-      letter-spacing: 1.2px;
-      text-shadow: 0 0 9px currentColor;
-    }
-    .secops-status {
-      display: inline-flex; align-items: center; gap: 6px;
-      font-weight: 700; text-transform: uppercase; white-space: nowrap;
-    }
-    .secops-dot {
-      width: 7px; height: 7px; border-radius: 50%;
-      background: currentColor; box-shadow: 0 0 8px currentColor; flex-shrink: 0;
-    }
-    @media (prefers-reduced-motion: no-preference) {
-      .secops-dot { animation: secops-pulse 1.8s ease-in-out infinite; }
-    }
-    @keyframes secops-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }
-    .secops-track {
-      position: relative; width: 150px; height: 4px;
-      background: var(--border); border-radius: 2px; overflow: hidden; flex-shrink: 0;
-    }
-    .secops-fill {
-      position: absolute; left: 0; top: 0; bottom: 0; width: 100%;
-      background: linear-gradient(90deg, transparent, currentColor);
-      opacity: 0.3; border-radius: 2px;
-    }
-    .secops-beam {
-      position: absolute; top: 0; bottom: 0; width: 44px;
-      background: linear-gradient(90deg, transparent 0%, currentColor 42%, #fff 50%, currentColor 58%, transparent 100%);
-    }
-    @media (prefers-reduced-motion: no-preference) {
-      .secops-beam { animation: kitt 2.2s linear infinite; }
-    }
-    @keyframes kitt { from { left: -44px; } to { left: 150px; } }
-    .secops-meta { color: var(--dim); font-size: 10px; white-space: nowrap; }
-    /* state → currentColor drives dot / beam / fill / status text */
-    .secops-bar[data-state="clean"]   { color: var(--accent); }
-    .secops-bar[data-state="issues"]  { color: var(--danger); }
-    .secops-bar[data-state="unknown"] { color: var(--muted); }
-
     /* ── Diff description + example pills ──────────────────────────── */
     .diff-desc {
       font-size: 17px;
@@ -1563,18 +1500,6 @@
 
       <!-- GitHub stats — CHANGE 6 -->
       <div class="gh-stats-bar" id="gh-stats"></div>
-
-      <!-- Sentrux quality strip -->
-      <div class="secops-bar" id="secops-bar" data-state="unknown" style="display:none" title="Trivy vulnerability scan — from GitHub code scanning, refreshed daily">
-        <span class="secops-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M12 2 4 5v6c0 5 3.4 8.5 8 10 4.6-1.5 8-5 8-10V5l-8-3z"/></svg></span>
-        <span class="secops-label">Trivy</span>
-        <span class="secops-status" id="secops-status">—</span>
-        <div class="secops-track">
-          <div class="secops-fill"></div>
-          <div class="secops-beam"></div>
-        </div>
-        <span class="secops-meta" id="secops-meta"></span>
-      </div>
 
       <!-- What's new panel -->
       <div class="whats-new-panel hidden" id="whats-new-panel">
@@ -2090,8 +2015,6 @@
       document.getElementById('stat-tasks').textContent = newTasks;
       document.getElementById('stat-pipeline').textContent =
         'Pipeline ' + (d.pipeline === 'healthy' ? 'healthy' : d.pipeline ?? 'unknown');
-
-      renderSecurity(d.security);
 
       const shadowCount = d.shadow_role_count ?? 0;
       if (shadowCount > 0) {
@@ -3376,33 +3299,6 @@ Content-Type: application/json
     const open = body.style.display !== 'none';
     body.style.display = open ? 'none' : '';
     chevron.classList.toggle('open', !open);
-  }
-
-  // ── Trivy security strip (SecDevOps night-rider) ──────────────────────
-  // Fed by /api/status → security (Trivy code-scanning posture, refreshed daily).
-  function renderSecurity(sec) {
-    const bar = document.getElementById('secops-bar');
-    if (!bar) return;
-    sec = sec || {};
-    const statusEl = document.getElementById('secops-status');
-    const metaEl   = document.getElementById('secops-meta');
-    const st = sec.status || 'unknown';
-    if (st === 'clean') {
-      bar.dataset.state = 'clean';
-      statusEl.innerHTML = '<span class="secops-dot"></span>Clean';
-    } else if (st === 'issues') {
-      bar.dataset.state = 'issues';
-      const parts = [];
-      if (sec.critical) parts.push(sec.critical + ' Critical');
-      if (sec.high)     parts.push(sec.high + ' High');
-      if (sec.medium)   parts.push(sec.medium + ' Medium');
-      statusEl.innerHTML = '<span class="secops-dot"></span>' + (parts.join(' · ') || (sec.total + ' issues'));
-    } else {
-      bar.dataset.state = 'unknown';
-      statusEl.innerHTML = '<span class="secops-dot"></span>Scanning…';
-    }
-    metaEl.textContent = sec.scanned_at ? 'code scan · ' + sec.scanned_at.slice(0, 10) : 'awaiting scan';
-    bar.style.display = 'flex';
   }
 
   // ── Browser history ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Two requested frontend changes:

1. **Removed the Trivy security-scan status bar** from the frontend entirely — HTML, CSS, and the `renderSecurity()` JS function + its `/api/status` call site. This is purely a frontend display removal; Trivy scanning itself (documented in the README's Security section, running in CI on every push) is untouched.

2. **Enlarged and restyled the What's New panel** — text throughout was too small (13px title, 14px rows, 10-12px detail text against a 17px base body font). Sized everything up (title 13→17px, entries 14→15.5px, detail text 12→13.5-14px, etc.), increased header/body padding, and gave the panel the same `surface2` + accent-left-border treatment already used for "How it works" and the AI-scenario callout, instead of the flat near-black background it had before.

Badges and hover states that referenced `--surface2` directly needed a fix too, since the panel itself now uses that color as its background — they'd have become invisible against it. Switched those to a translucent white overlay instead.

## Before / after (What's New, expanded entry)
Before: cramped 12-13px text, badges/hover blending into a near-black panel.
After: legible 14-17px text throughout, clear accent-bordered panel, scenario callout and badges both visibly distinct.

## Test plan
- [x] Headless-browser screenshots: panel collapsed, panel with an entry fully expanded (description, permissions, doc link, facts badges, AI scenario) — all render correctly at the larger sizes
- [x] Confirmed `#secops-bar` no longer exists in the DOM
- [x] Full functional regression: search, Role Diff, and What's New expand/collapse all work, 0 JS errors
- [ ] CI green
- [ ] Visual check on live site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)