### PR TITLE
fix(frontend): match the pills label to the app title's white glow

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1184,21 +1184,26 @@
     }
 
     /* ── Example pills ──────────────────────────────────────────────── */
+    @keyframes pills-label-glow {
+      0%, 100% { text-shadow: 0 0 3px rgba(226,232,240,0.95), 0 0 9px rgba(226,232,240,0.65), 0 0 20px rgba(226,232,240,0.3); }
+      50%       { text-shadow: 0 0 2px rgba(226,232,240,0.45), 0 0 5px rgba(226,232,240,0.2),  0 0 10px rgba(226,232,240,0.08); }
+    }
     .pills-label {
       display: flex;
       align-items: center;
-      gap: 6px;
-      font-family: var(--font-mono);
-      font-size: 11px;
-      font-weight: 700;
-      letter-spacing: 0.1em;
+      gap: 7px;
+      font-family: 'Chakra Petch', var(--font-head);
+      font-size: 15px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
       text-transform: uppercase;
-      color: var(--accent);
-      margin-top: 20px;
-      margin-bottom: 10px;
+      color: var(--text);
+      margin-top: 22px;
+      margin-bottom: 12px;
+      animation: pills-label-glow 3s ease-in-out infinite;
     }
     .pills-label.hidden { display: none; }
-    .pills-label::before { content: '⚡'; font-size: 11px; }
+    .pills-label::before { content: '⚡'; font-size: 13px; }
 
     .example-pills {
       display: flex;


### PR DESCRIPTION
## Summary
Follow-up to #159 based on feedback: the "Try it" label was styled as a small plain mono-uppercase tag, inconsistent with the site's actual visual identity. Restyled to match the hero title's own treatment:
- Font: `'Chakra Petch'` (same as `.hero-text`/`.hero-tagline`), already loaded — no new font request.
- Color: white (`var(--text)`), matching the hero title (not the blue accent tagline).
- Animation: the same pulsing text-shadow glow as `.hero-title-glow`, scaled down proportionally (3-9-20px blur vs. the hero's 8-22-50px) so it reads correctly at label size instead of blowing out.

Applies to both "Try it — click any example" (Task→Role) and "Try it — click any comparison" (Role Diff), since both share the `.pills-label` class.

## Test plan
- [x] Headless-browser screenshots of both labels confirm the glow renders correctly at the smaller size
- [x] `node --check` on the extracted inline script
- [ ] CI green
- [ ] Visual check on live site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)