### PR TITLE
fix(frontend): glowing NEW badge for added roles, larger/more readable What's New text

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -819,13 +819,13 @@
       display: flex;
       flex-direction: column;
       align-items: stretch;
-      padding: 18px 24px 16px;
+      padding: 22px 26px 18px;
       background: none;
       border: none;
       color: var(--text);
       cursor: pointer;
       text-align: left;
-      gap: 5px;
+      gap: 6px;
     }
     .whats-new-header:hover { background: rgba(255,255,255,0.02); }
 
@@ -835,24 +835,29 @@
       align-items: center;
       gap: 8px;
     }
+    @keyframes wn-title-glow {
+      0%, 100% { text-shadow: 0 0 3px rgba(47,158,245,0.9),  0 0 9px rgba(47,158,245,0.55), 0 0 20px rgba(47,158,245,0.25); }
+      50%       { text-shadow: 0 0 2px rgba(47,158,245,0.4),  0 0 5px rgba(47,158,245,0.15), 0 0 10px rgba(47,158,245,0.05); }
+    }
     .wn-title {
-      font-family: var(--font-mono);
-      font-size: 17px;
+      font-family: 'Chakra Petch', var(--font-head);
+      font-size: 21px;
       font-weight: 700;
       letter-spacing: 0.02em;
       color: var(--accent);
+      animation: wn-title-glow 3s ease-in-out infinite;
     }
     .whats-new-chevron { color: var(--muted); transition: transform 0.2s; flex-shrink: 0; width: 18px; height: 18px; }
     .whats-new-chevron.open { transform: rotate(180deg); }
 
     .wn-subtitle {
       font-family: var(--font-body);
-      font-size: 14px;
+      font-size: 15px;
       color: var(--muted);
     }
 
     .whats-new-body {
-      padding: 6px 24px 14px;
+      padding: 8px 26px 16px;
       border-top: 1px solid var(--border);
     }
 
@@ -863,9 +868,9 @@
     .whats-new-entry {
       display: flex;
       align-items: center;
-      gap: 12px;
-      padding: 13px 4px;
-      font-size: 15.5px;
+      gap: 13px;
+      padding: 15px 4px;
+      font-size: 17px;
       border-radius: 6px;
     }
 
@@ -898,10 +903,10 @@
     .wn-pgroup:first-child { margin-top: 2px; }
     .wn-phead {
       font-family: var(--font-mono);
-      font-size: 11.5px;
+      font-size: 13px;
       text-transform: uppercase;
       letter-spacing: 0.06em;
-      margin-bottom: 5px;
+      margin-bottom: 6px;
       opacity: 0.85;
     }
     .wn-phead.added   { color: var(--added); }
@@ -909,8 +914,8 @@
     .wn-perm {
       display: block;
       font-family: var(--font-mono);
-      font-size: 13px;
-      line-height: 1.65;
+      font-size: 14.5px;
+      line-height: 1.7;
       color: var(--muted);
       word-break: break-all;
     }
@@ -919,14 +924,14 @@
     .wn-perm .wn-sign { display: inline-block; width: 12px; font-weight: 700; }
     .wn-perm-rest[hidden] { display: none; }
     .wn-more-btn {
-      margin-top: 6px;
+      margin-top: 7px;
       background: none;
       border: 1px solid var(--border);
       border-radius: 6px;
       color: var(--muted);
       font-family: var(--font-mono);
-      font-size: 12.5px;
-      padding: 3px 10px;
+      font-size: 13.5px;
+      padding: 4px 12px;
       cursor: pointer;
     }
     .wn-more-btn:hover { color: var(--text); border-color: var(--muted); }
@@ -934,7 +939,7 @@
     /* Word-level diff: full text in context, only changed words highlighted. */
     .wn-worddiff {
       font-family: var(--font-body);
-      font-size: 13.5px;
+      font-size: 15px;
       color: var(--muted);
       line-height: 1.6;
     }
@@ -962,32 +967,32 @@
     .wn-privnote { font-family: var(--font-body); }
     .wn-priv-row {
       font-family: var(--font-mono);
-      font-size: 13.5px;
+      font-size: 15px;
       display: flex;
       align-items: baseline;
       gap: 10px;
     }
     .wn-priv-tag {
       color: var(--muted);
-      font-size: 11px;
+      font-size: 12px;
       text-transform: uppercase;
       letter-spacing: 0.06em;
-      width: 38px;
+      width: 42px;
       flex-shrink: 0;
     }
     .wn-priv-from { color: var(--muted); }
     .wn-priv-to   { color: var(--text); }
     .wn-priv-to.is-priv { color: var(--warn); font-weight: 600; }
-    .wn-priv-why  { font-size: 13.5px; color: var(--muted); line-height: 1.55; max-width: 70ch; margin-top: 5px; }
+    .wn-priv-why  { font-size: 15px; color: var(--muted); line-height: 1.55; max-width: 70ch; margin-top: 5px; }
 
     /* Count badges in the summary row (+N added / −N removed, privileged). */
     .wn-badges { display: inline-flex; gap: 5px; align-items: center; }
     .wn-badge {
       font-family: var(--font-mono);
-      font-size: 11.5px;
+      font-size: 13px;
       font-weight: 700;
       line-height: 1.5;
-      padding: 2px 8px;
+      padding: 2px 9px;
       border-radius: 999px;
       white-space: nowrap;
     }
@@ -1000,30 +1005,30 @@
     .wn-label-soft { color: var(--muted); }
 
     /* New-role expanded detail (description + permission list / no-perms note). */
-    .wn-role-desc { font-size: 14px; color: var(--muted); line-height: 1.6; margin-bottom: 10px; }
-    .wn-role-note { font-size: 14px; color: var(--muted); line-height: 1.6; font-style: italic; }
+    .wn-role-desc { font-size: 15.5px; color: var(--muted); line-height: 1.6; margin-bottom: 11px; }
+    .wn-role-note { font-size: 15.5px; color: var(--muted); line-height: 1.6; font-style: italic; }
 
     /* AI-generated real-world scenario + official docs link for a new role. */
     .wn-scenario {
-      font-size: 14px; color: var(--text); line-height: 1.6; margin-bottom: 12px;
-      padding: 12px 14px; background: rgba(255,255,255,0.03); border-radius: 6px;
+      font-size: 15.5px; color: var(--text); line-height: 1.6; margin-bottom: 13px;
+      padding: 14px 16px; background: rgba(255,255,255,0.03); border-radius: 6px;
       border-left: 2px solid var(--accent);
     }
     .wn-scenario-label {
-      display: flex; align-items: center; gap: 7px; font-size: 11px; text-transform: uppercase;
-      letter-spacing: .04em; color: var(--muted); margin-bottom: 5px;
+      display: flex; align-items: center; gap: 8px; font-size: 12px; text-transform: uppercase;
+      letter-spacing: .04em; color: var(--muted); margin-bottom: 6px;
     }
     .wn-ai-tag {
-      font-size: 10px; text-transform: none; letter-spacing: 0; font-weight: 600;
+      font-size: 11px; text-transform: none; letter-spacing: 0; font-weight: 600;
       color: var(--accent); background: rgba(255,255,255,0.03); border: 1px solid var(--accent);
-      padding: 1px 7px; border-radius: 999px;
+      padding: 1px 8px; border-radius: 999px;
     }
-    .wn-doclink { display: inline-block; margin-top: 6px; font-size: 14px; color: var(--accent); }
+    .wn-doclink { display: inline-block; margin-top: 7px; font-size: 15.5px; color: var(--accent); }
     .wn-doclink:hover { text-decoration: underline; }
 
     /* Deterministic role facts (pipeline-computed, never AI-generated). */
-    .wn-facts { display: flex; flex-wrap: wrap; gap: 7px; margin: 12px 0 5px; }
-    .wn-fact-configured { font-size: 13px; color: var(--muted); margin-bottom: 10px; }
+    .wn-facts { display: flex; flex-wrap: wrap; gap: 8px; margin: 13px 0 6px; }
+    .wn-fact-configured { font-size: 14.5px; color: var(--muted); margin-bottom: 11px; }
 
     .wn-fresh-dot {
       width: 7px;
@@ -1063,15 +1068,30 @@
       to { opacity: 1; transform: translateY(0); }
     }
 
-    .wn-glyph          { font-size: 15px; flex-shrink: 0; width: 18px; text-align: center; color: var(--added); }
+    .wn-glyph          { font-size: 16px; flex-shrink: 0; width: 20px; text-align: center; color: var(--added); }
     .wn-glyph.removed  { color: var(--danger); }
     .wn-glyph.modified { color: var(--warn); }
-    .wn-name   { font-family: var(--font-mono); font-size: 15px; font-weight: 500; color: var(--text); flex: 1; }
-    .wn-action { font-family: var(--font-body); font-size: 13.5px; color: var(--muted); }
+    @keyframes wn-new-badge-glow {
+      0%, 100% { text-shadow: 0 0 3px rgba(0,229,163,0.95), 0 0 9px rgba(0,229,163,0.65), 0 0 20px rgba(0,229,163,0.3); }
+      50%       { text-shadow: 0 0 2px rgba(0,229,163,0.45), 0 0 5px rgba(0,229,163,0.2),  0 0 10px rgba(0,229,163,0.08); }
+    }
+    .wn-new-badge {
+      font-family: 'Chakra Petch', var(--font-head);
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--added);
+      flex-shrink: 0;
+      white-space: nowrap;
+      animation: wn-new-badge-glow 3s ease-in-out infinite;
+    }
+    .wn-name   { font-family: var(--font-mono); font-size: 16.5px; font-weight: 500; color: var(--text); flex: 1; }
+    .wn-action { font-family: var(--font-body); font-size: 14.5px; color: var(--muted); }
     .whats-new-entry.type-added .wn-action    { color: var(--added); opacity: 0.85; }
     .whats-new-entry.type-modified .wn-action { color: var(--warn);   opacity: 0.85; }
     .whats-new-entry.type-removed .wn-action  { color: var(--danger); opacity: 0.85; }
-    .wn-date   { font-family: var(--font-mono); font-size: 13px; color: var(--muted); white-space: nowrap; }
+    .wn-date   { font-family: var(--font-mono); font-size: 14px; color: var(--muted); white-space: nowrap; }
 
     .wn-show-all { display: flex; justify-content: center; padding: 10px 0 4px; }
     .wn-show-all-btn {
@@ -3088,10 +3108,13 @@ Content-Type: application/json
       if (isFresh) tparts.push('changed in the last 24h');
       const titleAttr = tparts.length ? ` title="${tparts.join(' · ')}"` : '';
       const handlers  = exp ? ' role="button" tabindex="0" aria-expanded="false" onclick="_wnToggle(this)" onkeydown="_wnKey(event,this)"' : '';
+      const glyphHtml = type === 'ADDED'
+        ? `<span class="wn-new-badge">New</span>`
+        : `<span class="wn-glyph ${gcls}">${glyph}</span>`;
       return `<div class="wn-item${exp ? ' wn-expandable' : ''}">` +
         `<div class="whats-new-entry type-${gcls}${fresh}" data-idx="${startIdx + i}"${handlers}${titleAttr}>` +
           `<span class="wn-fresh-dot"${isFresh ? ' title="changed in the last 24h"' : ''}></span>` +
-          `<span class="wn-glyph ${gcls}">${glyph}</span>` +
+          glyphHtml +
           `<span class="wn-name">${esc(c.role_name ?? '')}</span>` +
           `<span class="wn-action">${_wnActionHtml(c)}</span>` +
           `<span class="wn-date">${esc(c.date ?? '')}</span>` +


### PR DESCRIPTION
## Summary
Follow-up to #159/#160 based on feedback: the small green sparkle icon next to a newly-added role was easy to miss, and the panel's text — even after the earlier enlargement pass — was still too small to read comfortably.

- **New-role rows** now show a glowing green **"New"** badge (Chakra Petch font, the same pulsing text-shadow glow as the app's hero title, in green) in place of the small sparkle glyph. Other change types (removed/modified) keep their existing glyph — "New" only makes sense for ADDED entries.
- **"What's new" header title** gets the same Chakra Petch + glow treatment as the "Try it" label from the previous PR (blue glow, matching its existing accent color).
- **Text sizes increased again, across the board**: entry rows 15.5→17px, permissions 13→14.5px, scenario/description/doc-link 14→15.5px, badges 11.5→13px, word-diff/privileged-note text similarly bumped, with more generous panel/header/body padding to match.

## Before / after
Before: small sparkle icon, 12-15.5px text throughout.
After: glowing green "NEW" badge, 13-17px text throughout, glowing blue panel title.

## Test plan
- [x] Headless-browser screenshots: collapsed panel and fully expanded entry, both showing the new badge and larger text correctly
- [x] Functional regression: What's New expand/collapse and core search both work, 0 JS errors
- [ ] CI green
- [ ] Visual check on live site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)