### PR TITLE
feat(ci): add Worker deploy automation

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,55 @@
+name: Deploy Worker
+
+# The Cloudflare Worker had no deploy automation at all -- unlike the
+# frontend (Cloudflare Pages Git integration, configured on Cloudflare's
+# side) and the data pipeline (direct D1/KV API calls from refresh.yml),
+# worker/src/index.ts and wrangler.toml changes only ever reached
+# production via someone manually running `wrangler deploy`. This closes
+# that gap: deploy on every push to master that touches worker/, plus a
+# manual trigger for one-off redeploys.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "worker/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-worker
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        working-directory: worker
+        run: npm ci
+
+      - name: Type-check
+        working-directory: worker
+        run: npm run type-check
+
+      - name: Deploy
+        working-directory: worker
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
Discovered while verifying the Sentrux decommission: `/api/quality` still returned live Sentrux data after that route was removed from `worker/src/index.ts` and merged. Root cause — the Worker has **no deploy automation at all**. Unlike the frontend (Cloudflare Pages Git integration, configured on Cloudflare's side) and the data pipeline (direct D1/KV API calls from `refresh.yml`), worker code and `wrangler.toml` changes only ever reached production via someone manually running `wrangler deploy`.

**Practical impact**: every worker-side change merged this session — the `compatibility_date`/observability bump (#150) and the `/api/quality` removal (#162) — is sitting in git but was never actually deployed.

## Change
New workflow: deploys on every push to master touching `worker/**`, plus `workflow_dispatch` for manual redeploys. Runs `npm run type-check` before `wrangler deploy` so a broken build never reaches production.

## ⚠️ Required manual step
The `rolelens-github-actions` token needs **"Workers Scripts: Edit"** permission added — same one-time Cloudflare dashboard step as the Workers AI permission added earlier today. Without it, this will fail with the same 401/403 pattern already hit twice this session (Workers AI, then this).

## Test plan
- [x] YAML validated
- [ ] CI green
- [ ] After merge + token permission added: manually trigger via `workflow_dispatch` to deploy the currently-pending worker changes, then confirm `/api/quality` returns 404 live

🤖 Generated with [Claude Code](https://claude.com/claude-code)