### PR TITLE
fix(ci): bump deploy-worker.yml to Node 22 (wrangler requirement)

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install dependencies
         working-directory: worker


### PR DESCRIPTION
## Summary
The first test run of `deploy-worker.yml` (#163) failed immediately, before even reaching the Cloudflare API call: `Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.` Not a token/permission problem at all — just needed a newer Node runtime for the wrangler CLI itself. Bumped `node-version` from 20 to 22.

## Test plan
- [x] YAML validated
- [ ] CI green
- [ ] After merge: re-trigger `workflow_dispatch` and confirm the deploy actually reaches the Cloudflare API this time (may still need the Workers Scripts: Edit permission if that hasn't been added yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)