### PR TITLE
fix(frontend): use current AboutCloud favicon instead of legacy icon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,9 @@
   <meta property="og:url" content="https://entrarolelens.aboutcloud.io" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" type="image/png" href="assets/logo_200x200_white.png" />
+  <link rel="icon" href="assets/aboutcloud-favicon.ico" sizes="any" />
+  <link rel="icon" type="image/png" href="assets/aboutcloud-icon-256.png" />
+  <link rel="apple-touch-icon" href="assets/aboutcloud-icon-256.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@400;500&family=Chakra+Petch:wght@300;400;500;600;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
Follow-up to #168 (header brand mark update). Swaps the browser-tab favicon from the legacy \`assets/logo_200x200_white.png\` to the current AboutCloud \`favicon.ico\` (multi-res 16x16/32x32) and \`icon.png\` (256x256) — both already fetched directly from aboutcloud.io in the previous PR, just not yet wired into the \`<head>\`. Added an \`apple-touch-icon\` link too for consistent iOS/mobile bookmarking.

## Test plan
- [x] Verified both favicon files serve correctly (HTTP 200) locally
- [x] `node --check` on the extracted inline script — no syntax issues introduced
- [ ] CI green
- [ ] Visual check on live site after merge (browser tab icon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)