### PR TITLE
polish(frontend): modernize the Task→Role / Role Diff tab toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -269,30 +269,34 @@
     }
     .tab-toggle {
       display: inline-flex;
-      background: var(--surface);
+      background: var(--surface2);
       border: 1px solid var(--border);
       border-radius: 100px;
-      padding: 4px;
+      padding: 5px;
     }
     .tab-pill {
-      font-family: var(--font-mono);
-      font-size: 14px;
-      font-weight: 500;
-      padding: 10px 28px;
+      font-family: 'Chakra Petch', var(--font-head);
+      font-size: 17px;
+      font-weight: 600;
+      padding: 13px 34px;
       border-radius: 100px;
       border: none;
       cursor: pointer;
       background: transparent;
-      color: #7885A8;
+      color: var(--muted);
       transition: all 0.2s ease;
       white-space: nowrap;
-      letter-spacing: 0.03em;
+      letter-spacing: 0.01em;
     }
     .tab-pill:hover { color: var(--text); }
     .tab-pill.active {
       background: var(--accent);
       color: #07080D;
-      font-weight: 600;
+      font-weight: 700;
+      box-shadow: 0 0 22px rgba(47,158,245,0.45);
+    }
+    @media (max-width: 640px) {
+      .tab-pill { font-size: 14px; padding: 11px 22px; }
     }
 
     /* ── Mode panels ────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
Requested: improve the text/font/size of the Task→Role / Role Diff tab-switcher buttons. Same underlying issue as the header tagline before this session's fixes — small (14px) plain monospace text in a flat container (\`var(--surface)\`, the same near-invisible-against-black token already fixed elsewhere this session for the pills and the "How it works" box).

## Changes
- **Font**: monospace → \`'Chakra Petch'\` 600/700, matching the display font now established everywhere else on the page.
- **Size**: 14px → 17px desktop (new 14px mobile breakpoint added — didn't exist before), padding bumped to match.
- **Container**: \`var(--surface)\` → \`var(--surface2)\`, consistent with the other "stop blending into black" fixes this session.
- **Active tab**: kept its solid accent fill, added a soft static glow shadow so it reads as a deliberate highlight rather than a flat color swap (static, not animated — no mobile-performance concern to gate).

## Test plan
- [x] Mode-switching logic untouched, confirmed still fully functional: clicking either tab correctly activates its panel, search still works
- [x] Computed-style checks: new font/size/background applied, active-tab glow shadow present and correctly follows whichever tab is active
- [x] Fresh subagent screenshot verification: container clearly visible (not blending into background), both labels render cleanly without overflow, active-state glow correctly transfers between tabs on click
- [ ] CI green
- [ ] Visual check on live site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)