### PR TITLE
copy(frontend): hero headline says "Entra ID" instead of "Entra"

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1631,7 +1631,7 @@
 
     <!-- MODE 1: Task → Role -->
     <section class="mode active" id="mode-search">
-      <h1 class="hero-text">Find the minimum role for any Entra task</h1>
+      <h1 class="hero-text">Find the minimum role for any Entra ID task</h1>
       <p class="hero-tagline">The right role. Right now.</p>
 
       <!-- Sync bar — CHANGE 4 -->


### PR DESCRIPTION
Changes the hero H1 from "Find the minimum role for any Entra task" to "Find the minimum role for any Entra ID task", matching the naming already used in the page `<title>`, meta description, and og tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)