### PR TITLE
polish(frontend): redesign GitHub stats bar + enlarge/upgrade GitHub icons

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -178,10 +178,20 @@
       text-decoration: none;
       display: flex;
       align-items: center;
-      transition: color 0.15s;
+      justify-content: center;
+      width: 38px;
+      height: 38px;
+      border-radius: 50%;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      transition: all 0.2s ease;
     }
-    .gh-link:hover { color: var(--text); }
-    .gh-link svg { width: 20px; height: 20px; }
+    .gh-link:hover {
+      color: var(--text);
+      border-color: var(--accent-dim);
+      box-shadow: 0 0 16px rgba(47,158,245,0.3);
+    }
+    .gh-link svg { width: 22px; height: 22px; }
 
     /* ── AboutCloud brand mark (source of truth: aboutcloud.io) ────────── */
     .ac-brand {
@@ -1442,23 +1452,44 @@
     .gh-stats-bar {
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: 8px;
       flex-wrap: wrap;
       margin-bottom: 24px;
-      font-family: var(--font-mono);
-      font-size: 14px;
-      color: var(--muted);
     }
     .gh-stats-link {
       display: flex;
       align-items: center;
+      justify-content: center;
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+      background: var(--surface2);
+      border: 1px solid var(--border);
       color: var(--muted);
       text-decoration: none;
-      transition: color 0.15s;
+      transition: all 0.2s ease;
     }
-    .gh-stats-link:hover { color: var(--text); }
-    .gh-stat { white-space: nowrap; }
-    .gh-stat-sep { color: var(--border); user-select: none; }
+    .gh-stats-link:hover {
+      color: var(--text);
+      border-color: var(--accent-dim);
+      box-shadow: 0 0 14px rgba(47,158,245,0.25);
+    }
+    .gh-stats-link svg { width: 18px; height: 18px; }
+    .gh-stat {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      white-space: nowrap;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 7px 14px;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--muted);
+    }
+    .gh-stat svg { width: 14px; height: 14px; flex-shrink: 0; color: var(--accent); }
+    .gh-stat strong { color: var(--text); font-weight: 600; }
 
     /* ── Diff description + example pills ──────────────────────────── */
     .diff-desc {
@@ -3026,15 +3057,24 @@ Content-Type: application/json
     }
     el.innerHTML = `
       <a href="https://github.com/arusso-aboutcloud/entra-rolelens" target="_blank" rel="noopener" class="gh-stats-link" aria-label="GitHub repo">
-        <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.741 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.741 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>
       </a>
-      <span class="gh-stat">⭐ ${stats.stars}</span>
-      <span class="gh-stat-sep">·</span>
-      <span class="gh-stat">🔀 ${stats.forks}</span>
-      <span class="gh-stat-sep">·</span>
-      <span class="gh-stat">Issues: ${stats.issues} open</span>
-      <span class="gh-stat-sep">·</span>
-      <span class="gh-stat">Last commit: ${commitStr}</span>`;
+      <span class="gh-stat" aria-label="${stats.stars} stars">
+        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+        <strong>${stats.stars}</strong>
+      </span>
+      <span class="gh-stat" aria-label="${stats.forks} forks">
+        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"/></svg>
+        <strong>${stats.forks}</strong>
+      </span>
+      <span class="gh-stat" aria-label="${stats.issues} open issues">
+        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/></svg>
+        <strong>${stats.issues}</strong> open
+      </span>
+      <span class="gh-stat" aria-label="Last commit ${commitStr}">
+        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/><path d="M9.5 8.75V4.75a.75.75 0 0 0-1.5 0v4.5a.75.75 0 0 0 .22.53l2.5 2.5a.75.75 0 1 0 1.06-1.06l-2.28-2.28Z"/></svg>
+        ${commitStr}
+      </span>`;
   }
 
   // ── Utility ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Replaces the emoji-based GitHub stats row (⭐ 36 · 🔀 8 · Issues: 1 open · Last commit: today) with proper SVG Octicons in pill badges, and enlarges/upgrades both GitHub icon links (header + stats bar) into circular chip buttons consistent with the rest of the site's icon language.

Before: plain emoji + monospace text + dot separators, tiny bare octocat icons.
After: star/fork/issue/clock Octicons in accent blue, each in a rounded pill badge; octocat icons enlarged (20px→22px) and housed in a circular dark chip with hover glow.

Verified locally via Playwright (styles, zero JS errors, live GitHub API populates correctly) and a fresh screenshot review confirming crisp icon rendering with no overlap/clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)