### PR TITLE
feat(pipeline+frontend): surface real docs-confirmation status + doc link on permission changes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1138,6 +1138,17 @@
     .wn-doclink { display: inline-block; margin-top: 7px; font-size: 15.5px; color: var(--accent); }
     .wn-doclink:hover { text-decoration: underline; }
 
+    /* Permission-change entries: whether Microsoft's own docs actually list
+       the added permissions yet, since the docs can lag (or never catch up
+       with) a live Graph API grant -- see diff_roles.py's undocumented_permissions. */
+    .wn-docs-note {
+      font-size: 14px; line-height: 1.55; margin: 2px 0 11px; padding: 8px 12px;
+      border-radius: 6px; max-width: 60ch;
+    }
+    .wn-docs-note.confirmed { color: var(--added); background: rgba(0, 229, 163, 0.08); }
+    .wn-docs-note.pending   { color: var(--warn);  background: rgba(251, 191, 36, 0.08); }
+    .wn-docs-note.partial   { color: var(--warn);  background: rgba(251, 191, 36, 0.08); }
+
     /* Deterministic role facts (pipeline-computed, never AI-generated). */
     .wn-facts { display: flex; flex-wrap: wrap; gap: 8px; margin: 13px 0 6px; }
     .wn-fact-configured { font-size: 14.5px; color: var(--muted); margin-bottom: 11px; }
@@ -3190,6 +3201,27 @@ Content-Type: application/json
     return s;
   }
 
+  // Whether Microsoft's own docs page currently lists the added permissions.
+  // Neither the Graph API nor the docs expose *when* a role's permissions
+  // actually changed live -- only that they did (via the Graph API right now)
+  // and whether the docs happen to reflect it. Rather than showing a single
+  // "date" that reads as "this changed on X" (it doesn't -- it's the date
+  // RoleLens detected it), this makes the real, verifiable status explicit.
+  function _wnDocsStatus(c) {
+    const added = c.added_permissions || [];
+    if (!added.length) return '';
+    const undocumented = c.undocumented_permissions || [];
+    const reviewed = c.docs_reviewed_date
+      ? ` (Microsoft's docs page last reviewed ${esc(c.docs_reviewed_date)})` : '';
+    if (undocumented.length === 0) {
+      return `<div class="wn-docs-note confirmed">✓ Confirmed in Microsoft's official docs${reviewed}.</div>`;
+    }
+    if (undocumented.length === added.length) {
+      return `<div class="wn-docs-note pending">Not yet reflected in Microsoft's public docs — detected via the live Microsoft Graph API. The exact date this was granted isn't published anywhere.</div>`;
+    }
+    return `<div class="wn-docs-note partial">${undocumented.length} of ${added.length} added permission${added.length === 1 ? '' : 's'} not yet reflected in Microsoft's public docs${reviewed}.</div>`;
+  }
+
   // One permission section (Added / Removed) with a header + count, capping at
   // _WN_PERM_CAP rows with a "+N more" toggle for the remainder.
   function _wnPermSection(perms, cls, sign, title) {
@@ -3225,8 +3257,13 @@ Content-Type: application/json
       return `<div class="wn-lazy" data-role="${esc(c.role_id)}"${scenarioAttr}${factsAttr}></div>`;
     }
     if (c.field === 'permissions') {
-      return _wnPermSection(c.added_permissions, 'added', '+', 'Added') +
-             _wnPermSection(c.removed_permissions, 'removed', '−', 'Removed');
+      const doclink = c.role_name
+        ? `<a class="wn-doclink" href="${esc(_roleDocsUrl(c.role_name))}" target="_blank" rel="noopener">Microsoft Learn: official role documentation ↗</a>`
+        : '';
+      return _wnDocsStatus(c) +
+             _wnPermSection(c.added_permissions, 'added', '+', 'Added') +
+             _wnPermSection(c.removed_permissions, 'removed', '−', 'Removed') +
+             doclink;
     }
     if (c.field === 'description' || c.field === 'displayName') {
       let oldV = c.old, newV = c.new;
@@ -3425,10 +3462,14 @@ Content-Type: application/json
       const cutoff24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
       // Newest first: the changelog is stored oldest→newest (append log), so
       // sort descending by date so the most recent changes sit at the top and
-      // are visible without expanding.
+      // are visible without expanding. Entries sharing the same date (e.g. a
+      // batch caught by one pipeline run) get a deterministic alphabetical
+      // tie-break instead of falling back to whatever order the backend
+      // happened to emit them in.
       const recent   = changelog
         .filter(c => c.date >= cutoff)
-        .sort((a, b) => (b.date || '').localeCompare(a.date || ''))
+        .sort((a, b) => (b.date || '').localeCompare(a.date || '') ||
+                         (a.role_name || '').localeCompare(b.role_name || ''))
         .slice(0, 50);
       if (!recent.length) return;
 

--- a/pipeline/diff_roles.py
+++ b/pipeline/diff_roles.py
@@ -133,6 +133,23 @@ def compute_changes(old_roles: dict, new_roles: dict) -> list[dict]:
                 entry["added_permissions"] = added
             if removed:
                 entry["removed_permissions"] = removed
+
+            # This "date" is when RoleLens detected the change, NOT when
+            # Microsoft actually granted it live -- neither the Graph API nor
+            # the docs expose that. What we CAN verify: whether the specific
+            # added permissions are actually listed on Microsoft's own docs
+            # page right now, and if so, that page's own ms.date (its last
+            # reviewed date, not necessarily this permission's date either --
+            # a page can be touched for unrelated reasons and still miss a
+            # live grant, so this is only trusted when the exact permission
+            # string is present in that page's current content).
+            docs_perms = set(new_role.get("permissionsInDocs", []))
+            undocumented = sorted(set(added) - docs_perms) if added else []
+            if added and undocumented != added:
+                # At least one added permission IS in the current docs.
+                entry["docs_reviewed_date"] = new_role.get("docsReviewedDate")
+            if undocumented:
+                entry["undocumented_permissions"] = undocumented
             changes.append(entry)
 
     return changes

--- a/pipeline/enrich.py
+++ b/pipeline/enrich.py
@@ -110,6 +110,12 @@ def build_merged_roles(
                 "isPrivileged": docs_role.get("isPrivileged", False),
                 "permissions":  permissions,
                 "isShadowRole": False,
+                # Kept separately (not just derivable from the union above) so
+                # diff_roles.py can tell exactly which of a change's added
+                # permissions Microsoft's docs actually list vs. grants that
+                # are live-only and undocumented -- see diff_roles.py.
+                "permissionsInDocs": sorted(set(docs_role.get("permissions", []))),
+                "docsReviewedDate":  docs_role.get("docsReviewedDate"),
             })
         else:
             # Shadow role — present in API, absent from docs (Graph is all we have)

--- a/pipeline/fetch_roles.py
+++ b/pipeline/fetch_roles.py
@@ -155,20 +155,38 @@ def parse_permissions(md: str) -> list[str]:
     return [m.group(1) for m in perm_re.finditer(md)]
 
 
-def fetch_permissions(slug: str) -> list[str]:
+_MS_DATE_RE = re.compile(r"^ms\.date:\s*(\d{2})/(\d{2})/(\d{4})\s*$", re.MULTILINE)
+
+
+def parse_docs_reviewed_date(md: str) -> str | None:
+    """Microsoft's include-file YAML frontmatter carries an ms.date field --
+    the date that specific docs page was last reviewed/touched. NOT the same
+    as when a role's permissions actually changed (a page can be reviewed for
+    unrelated reasons and still miss a live permission change entirely -- see
+    diff_roles.py's docs-vs-live reconciliation), but it's a real, verifiable
+    signal worth surfacing rather than inventing a change date Microsoft never
+    published."""
+    m = _MS_DATE_RE.search(md)
+    if not m:
+        return None
+    mm, dd, yyyy = m.groups()
+    return f"{yyyy}-{mm}-{dd}"
+
+
+def fetch_permissions(slug: str) -> tuple[list[str], str | None]:
     url = INCLUDE_URL.format(slug=slug)
     md = get(url)
     if not md:
         print(f"  WARN: no include file for '{slug}' — permissions will be empty",
               file=sys.stderr)
-        return []
-    return parse_permissions(md)
+        return [], None
+    return parse_permissions(md), parse_docs_reviewed_date(md)
 
 
 def enrich_role(role: dict) -> dict:
     slug = role.pop("_slug")
-    permissions = fetch_permissions(slug)
-    return {**role, "permissions": permissions}
+    permissions, docs_reviewed_date = fetch_permissions(slug)
+    return {**role, "permissions": permissions, "docsReviewedDate": docs_reviewed_date}
 
 
 def main() -> None:


### PR DESCRIPTION
Direct follow-up to a question raised after #179: the "date" on a permission-change entry is when RoleLens *detected* the change, not when Microsoft actually granted it live -- there's no published "granted on" timestamp anywhere (Graph API or docs), so showing just a bare date risks being misread as the actual change date.

## What's now surfaced, and how it stays honest
- Microsoft's docs pages carry an `ms.date` field (last-reviewed date). Parsed per role, but **only trusted when the specific added permission is actually present in that page's current content** -- verified this distinction matters: Global Administrator's docs page has a *more recent* `ms.date` than several other roles, yet still doesn't list any of its 11 new permissions. Using the raw date alone would have been misleading.
- Each permission-change changelog entry now gets `docs_reviewed_date` (only when something is actually confirmed) and `undocumented_permissions` (exactly which added permissions Microsoft's docs don't list yet).
- Frontend renders this as a clear status note: green "Confirmed in Microsoft's official docs", amber "N of M not yet reflected", or amber "not yet reflected -- detected via the live Graph API" -- plus the same official Microsoft Learn doc link ADDED entries already had.
- Sort: was already newest-date-first; added an alphabetical tie-break for same-date entries so ordering isn't arbitrary.

## Verification
- Unit tests for the frontmatter parser (valid/missing/malformed date).
- End-to-end enrich.py + diff_roles.py test across all three documentation states, confirming `docs_reviewed_date` is never claimed unless something is actually confirmed.
- Playwright + fresh screenshot review: all three UI states render with correct color/copy/contrast, doc link present in every case, zero JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
