### PR TITLE
fix(frontend): don't falsely claim docs-confirmation for pre-#180 entries

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3210,6 +3210,16 @@ Content-Type: application/json
   function _wnDocsStatus(c) {
     const added = c.added_permissions || [];
     if (!added.length) return '';
+    // Entries from before this feature shipped have neither field at all --
+    // that MUST read as "we don't know," never as "0 undocumented" (which
+    // would falsely claim full confirmation). Only render a status once
+    // diff_roles.py has actually recorded one: docs_reviewed_date is present
+    // whenever at least one added permission is confirmed, and
+    // undocumented_permissions is present whenever at least one isn't -- so
+    // an entry with neither key at all means the check was never run, not
+    // that everything checked out clean.
+    const hasStatus = ('docs_reviewed_date' in c) || ('undocumented_permissions' in c);
+    if (!hasStatus) return '';
     const undocumented = c.undocumented_permissions || [];
     const reviewed = c.docs_reviewed_date
       ? ` (Microsoft's docs page last reviewed ${esc(c.docs_reviewed_date)})` : '';


### PR DESCRIPTION
**Urgent correctness fix — currently live and actively wrong.**

`_wnDocsStatus()` (added in #180) defaulted `c.undocumented_permissions || []`. Any changelog entry that predates #180 -- added_permissions set, but neither `docs_reviewed_date` nor `undocumented_permissions` present -- read as "0 undocumented" and rendered a false green "✓ Confirmed in Microsoft's official docs" badge.

That includes all 17 of today's backfilled entries. For Application Developer specifically, we independently confirmed Microsoft's docs do **not** reflect that permission change -- so the live site is currently telling users the opposite of the truth on that exact entry.

## Fix
Only render a docs-status note when diff_roles.py has actually recorded one (`docs_reviewed_date` or `undocumented_permissions` present as a key). An entry with neither now shows nothing -- honest silence instead of a guess.

## Verification
Synthetic test: a pre-#180-shaped entry (added_permissions only, no status fields) now renders no note at all; a genuinely confirmed entry is unaffected. Zero JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
