### PR TITLE
fix(docs): top-of-README status badges had the same white-on-green contrast bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 # Entra RoleLens
 
-[![Live](https://img.shields.io/website?url=https%3A%2F%2Fentrarolelens.aboutcloud.io&label=live&style=flat-square&color=00E5A3)](https://entrarolelens.aboutcloud.io)
-[![Pipeline](https://img.shields.io/github/actions/workflow/status/arusso-aboutcloud/entra-rolelens/refresh.yml?label=nightly%20pipeline&style=flat-square&branch=master&color=00E5A3)](https://github.com/arusso-aboutcloud/entra-rolelens/actions)
-[![Last commit](https://img.shields.io/github/last-commit/arusso-aboutcloud/entra-rolelens/master?style=flat-square&color=00E5A3)](https://github.com/arusso-aboutcloud/entra-rolelens/commits/master)
+[![Live](https://img.shields.io/website?url=https%3A%2F%2Fentrarolelens.aboutcloud.io&label=live&style=flat-square&color=007A53)](https://entrarolelens.aboutcloud.io)
+[![Pipeline](https://img.shields.io/github/actions/workflow/status/arusso-aboutcloud/entra-rolelens/refresh.yml?label=nightly%20pipeline&style=flat-square&branch=master&color=007A53)](https://github.com/arusso-aboutcloud/entra-rolelens/actions)
+[![Last commit](https://img.shields.io/github/last-commit/arusso-aboutcloud/entra-rolelens/master?style=flat-square&color=007A53)](https://github.com/arusso-aboutcloud/entra-rolelens/commits/master)
 [![License](https://img.shields.io/badge/license-MIT-38BDF8?style=flat-square)](LICENSE)
 [![Roles](https://img.shields.io/badge/dynamic/json?url=https://rolelens-worker.russo-antonio76.workers.dev/api/status&query=role_count&label=roles&color=0078D4&logo=microsoft&style=flat-square)](https://entrarolelens.aboutcloud.io)
 [![Tasks](https://img.shields.io/badge/dynamic/json?url=https://rolelens-worker.russo-antonio76.workers.dev/api/status&query=task_count&label=tasks&color=0078D4&logo=microsoft&style=flat-square)](https://entrarolelens.aboutcloud.io)
 [![Unlisted roles](https://img.shields.io/badge/dynamic/json?url=https://rolelens-worker.russo-antonio76.workers.dev/api/status&query=shadow_role_count&label=unlisted%20roles&color=E5A300&style=flat-square)](https://entrarolelens.aboutcloud.io)
-[![Stars](https://img.shields.io/github/stars/arusso-aboutcloud/entra-rolelens?style=flat-square&color=00E5A3)](https://github.com/arusso-aboutcloud/entra-rolelens/stargazers)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-00E5A3?style=flat-square)](CONTRIBUTING.md)
+[![Stars](https://img.shields.io/github/stars/arusso-aboutcloud/entra-rolelens?style=flat-square&color=007A53)](https://github.com/arusso-aboutcloud/entra-rolelens/stargazers)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-007A53?style=flat-square)](CONTRIBUTING.md)
 
 [![LinkedIn](https://img.shields.io/badge/Connect%20on%20LinkedIn-Antonio%20Russo-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/antonio-russo-9295731b/)
 


### PR DESCRIPTION
Found while fixing the What's new badges' contrast (#185): the Live, Pipeline, Last commit, Stars, and PRs Welcome badges at the top of the README all used `color=00E5A3` -- the exact same site-token green that gives white badge text a 1.65:1 contrast ratio. Same root cause as #185, same fix: darker same-hue green (`#007A53`, 5.37:1 vs white).

Also spot-checked every other badge color in that row: License (`#38BDF8`, 2.14:1) and Unlisted roles (`#E5A300`, 2.19:1) are technically under WCAG AA too, but they're different colors than what was reported and a separate change -- left alone, flagging for a decision rather than assuming.

Verified: all 5 updated badge URLs return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)