### PR TITLE
fix(diff): explain zero-permission workload roles in Role Diff

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1557,6 +1557,17 @@
       color: var(--text);
       margin-bottom: 16px;
     }
+    /* Shown when one or both compared roles carry zero Entra directory
+       permissions -- e.g. Purview Workload Content roles, which are governed
+       entirely within their own service portal. Without this, a 0/0/0 diff
+       grid reads as a broken result rather than an expected one. */
+    .diff-zero-note {
+      display: none;
+      font-size: 14.5px; line-height: 1.6; margin: -4px 0 18px; padding: 10px 14px;
+      border-radius: 6px; max-width: 68ch;
+      color: var(--accent); background: rgba(47, 158, 245, 0.08);
+    }
+    .diff-zero-note.visible { display: block; }
 
     /* ── More tools section ─────────────────────────────────────────── */
     .tools-section {
@@ -1877,6 +1888,7 @@
 
       <div id="diff-results">
         <div class="diff-summary" id="diff-summary"></div>
+        <div class="diff-zero-note" id="diff-zero-note"></div>
         <div class="diff-header" id="diff-header"></div>
         <div class="diff-grid" id="diff-grid"></div>
       </div>
@@ -3015,6 +3027,28 @@ Content-Type: application/json
 
     const newBadgeA = isNewRole(ra.id) ? NEW_BADGE : '';
     const newBadgeB = isNewRole(rb.id) ? NEW_BADGE : '';
+
+    // Some built-in roles (Purview Workload Content roles are the current
+    // example) carry zero Entra directory permissions by design — access is
+    // governed entirely within their own service portal, not the Entra admin
+    // center. Without a note, a 0/0/0 result reads as a broken diff rather
+    // than an expected one. Kept service-agnostic: applies to any role with
+    // permission_count === 0, not hardcoded to Purview.
+    const zeroNoteEl = document.getElementById('diff-zero-note');
+    if (zeroNoteEl) {
+      const aZero = ra.permission_count === 0;
+      const bZero = rb.permission_count === 0;
+      let note = '';
+      if (aZero && bZero) {
+        note = `Neither role carries any Entra directory permissions — there's nothing to diff at the permission level. Both are workload roles governed within their own service portal, not the Entra admin center. See each role's description for where access is actually managed.`;
+      } else if (aZero) {
+        note = `${esc(ra.display_name)} carries no Entra directory permissions — it's a workload role governed within its own service portal, not the Entra admin center. All permissions below belong to ${esc(rb.display_name)}.`;
+      } else if (bZero) {
+        note = `${esc(rb.display_name)} carries no Entra directory permissions — it's a workload role governed within its own service portal, not the Entra admin center. All permissions below belong to ${esc(ra.display_name)}.`;
+      }
+      zeroNoteEl.innerHTML = note;
+      zeroNoteEl.classList.toggle('visible', !!note);
+    }
 
     document.getElementById('diff-header').innerHTML = `
       <div class="diff-col-header">


### PR DESCRIPTION
## What
Adds an informational callout to the Role Diff view when one or both compared roles carry zero Entra directory permissions (e.g. Purview Workload Content roles, whose access is governed entirely within Purview's own portal RBAC, not through Entra role permission strings).

## Why
Reported by Antonio: several pre-built Role Diff pairs looked broken, e.g. "Purview Workload Content Administrator (0 permissions) vs Purview Workload Content Reader (0 permissions)" rendering a bare 0/0/0 grid.

Root cause: this is **not a data bug** — both roles genuinely have zero Entra directory permissions in production (confirmed live via `/api/role/:id` and `/api/diff`). The What's New panel's per-role detail view (`_wnLoadRole`) already explains this exact case with a clear note. Role Diff's `renderDiff()` had no equivalent, so the same legitimate zero-permission state rendered with no context in that view only.

Scope check: of the 17 pre-built Role Diff pairs, exactly **2** are affected (both Purview Workload Content pairs). All other 15 have nonzero permission counts on both sides.

## Fix
- New `.diff-zero-note` callout, styled consistently with the existing `.wn-docs-note` pattern.
- `renderDiff()` now checks `permission_count === 0` on either role and shows service-agnostic copy (not hardcoded to Purview) — distinct wording for "both zero" vs. "one zero" cases.
- Hidden by default; only shown when it applies.

## Verified
Local Playwright run against the live worker API:
- Purview Workload Content Administrator vs Reader (both zero) → note shown, correct copy
- Purview Workload Content Reader vs Security Reader (one zero) → note shown, correct copy, permission list for the non-zero role renders normally
- Global Administrator vs User Administrator (neither zero) → note stays hidden, no visual change

Screenshots taken locally confirm placement/styling reads cleanly in all three cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)