### PR TITLE
fix(header): keep AboutCloud brand ring spinning on mobile

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -239,11 +239,13 @@
     .ac-ring-cw {
       background: conic-gradient(from 0deg, #00d4ff, transparent 70%, #00d4ff);
       animation: ac-spin-cw 3.8s linear infinite;
+      will-change: transform;
     }
     .ac-ring-ccw {
       background: conic-gradient(from 0deg, #7fe3ff, transparent 70%, #7fe3ff);
       opacity: 0.8;
       animation: ac-spin-ccw 5.2s linear infinite;
+      will-change: transform;
     }
     @keyframes ac-spin-cw  { to { transform: rotate(360deg); } }
     @keyframes ac-spin-ccw { to { transform: rotate(-360deg); } }
@@ -251,10 +253,16 @@
       .ac-ring-cw  { animation: none; transform: rotate(20deg); }
       .ac-ring-ccw { animation: none; transform: rotate(-20deg); }
     }
-    @media (pointer: coarse) {
-      .ac-ring-cw  { animation: none; transform: rotate(20deg); }
-      .ac-ring-ccw { animation: none; transform: rotate(-20deg); }
-    }
+    /* Unlike the text-shadow/box-shadow glows below (and the WebGL bg),
+       the ring only animates `transform`, which is compositor-only and
+       doesn't force main-thread repaint -- measured no FPS/task-time
+       regression under the same Pixel 5 + 4x-CPU-throttle profile used for
+       the pointer:coarse perf fix (#170), so it doesn't need the freeze
+       that pass swept it into. will-change: transform (above) hints the
+       browser to promote it to its own layer despite the mask, since a
+       masked element can otherwise fall back to main-thread compositing on
+       some engines. Left spinning on mobile; the
+       prefers-reduced-motion freeze above still applies for accessibility. */
 
     @media (max-width: 640px) {
       .ac-chip { width: 44px; height: 44px; border-radius: 12px; }


### PR DESCRIPTION
## What
The AboutCloud logo's counter-rotating ring in the header no longer freezes on mobile.

## Why
Reported: on mobile phones the ring reads as stale/not moving. Root cause: #170 (the mobile CPU perf fix) swept the ring's animation into the same `pointer: coarse` freeze as the genuinely expensive text-shadow/box-shadow glows and the WebGL background — but the ring only ever animates `transform`, which is compositor-only and doesn't force main-thread repaint the way those others do.

## Verified
Same methodology as #170 (Playwright + CDP, Pixel 5 emulation, 4x CPU throttle):

| | idle FPS | main-thread busy (3s window) |
|---|---|---|
| ring frozen (as shipped) | 60.6 | 0.000s |
| ring unfrozen | 60.3 | 0.002s |

No measurable regression from leaving the ring spinning. `will-change: transform` added defensively, since the ring is a masked element (`mask-composite: exclude`) and some engines don't promote masked layers to their own compositor layer without a hint.

`prefers-reduced-motion` freeze is untouched — accessibility signal, not a perf one.

## Scope
Same fix applied to the sibling sites with the identical chip (Entra Tracker, AADSTS Entra Errors, EntraPass) in their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)